### PR TITLE
 fix: 修复WHU个人信息页未登录Bug及首次运行yarn res时会找不到文件的问题

### DIFF
--- a/resource/sites/whu.pt/config.json
+++ b/resource/sites/whu.pt/config.json
@@ -239,5 +239,16 @@
         }
       ]
     }
-  ]
+  ],
+  "selectors": {
+    "userBaseInfo": {
+      "merge": true,
+      "fields": {
+        "isLogged": {
+          "selector": ["form[action*='\/\/whu.pt\/logout.php']"],
+          "filters": ["query.length>0"]
+        }
+      }
+    }
+  }
 }

--- a/test/src/BuildPlugin.ts
+++ b/test/src/BuildPlugin.ts
@@ -8,7 +8,7 @@ export class BuildPlugin {
   public resourcePath: string = "";
   private resourceMap = ["sites", "schemas", "clients"];
 
-  constructor(rootPaht: string = "../../dist/resource") {
+  constructor(rootPaht: string = "../../resource") {
     this.resourcePath = PATH.resolve(__dirname, rootPaht);
     console.log(this.resourcePath);
   }


### PR DESCRIPTION
1. WHU的登出是用的一个post，所以在原NexusPHP模板下会出现未登录（因为找不到a[href*='logout.php']），因此将其改成了WHU页面的形式

2. 编译配置文件时不应依赖运行yarn build/dev编译出来的的dist文件夹，而应该是源文件夹，因为yarn res时还没有dist文件夹