### PR TITLE
add lztr,red,ops,dic site

### DIFF
--- a/resource/sites/dicmusic.club/config.json
+++ b/resource/sites/dicmusic.club/config.json
@@ -1,0 +1,9 @@
+{
+  "name": "DIC",
+  "description": "music",
+  "url": "https://dicmusic.club/",
+  "icon": "https://dicmusic.club/favicon.ico",
+  "tags": ["音乐"],
+  "schema": "Gazelle",
+  "host": "dicmusic.club"
+}

--- a/resource/sites/lztr.me/config.json
+++ b/resource/sites/lztr.me/config.json
@@ -1,0 +1,9 @@
+{
+  "name": "LzTr",
+  "description": "music",
+  "url": "https://lztr.me/",
+  "icon": "https://lztr.me/favicon.ico",
+  "tags": ["音乐"],
+  "schema": "Gazelle",
+  "host": "lztr.me"
+}

--- a/resource/sites/orpheus.network/config.json
+++ b/resource/sites/orpheus.network/config.json
@@ -1,0 +1,9 @@
+{
+  "name": "OPS",
+  "description": "music",
+  "url": "https://orpheus.network/",
+  "icon": "https://orpheus.network/favicon.ico",
+  "tags": ["音乐"],
+  "schema": "Gazelle",
+  "host": "orpheus.network"
+}

--- a/resource/sites/redacted.ch/config.json
+++ b/resource/sites/redacted.ch/config.json
@@ -1,0 +1,9 @@
+{
+  "name": "RED",
+  "description": "music",
+  "url": "https://redacted.ch/",
+  "icon": "https://redacted.ch/favicon.ico",
+  "tags": ["音乐"],
+  "schema": "Gazelle",
+  "host": "redacted.ch"
+}


### PR DESCRIPTION
- feat: 添加lztr,red,ops,dic站点；
- 4个站点的搜索功能和下载，批量下载，批量复制均可使用；
- red,ops,dic的torrents.php页面尚且无法批量复制或下载；
- lztr适配最完全，概览也可正常使用。