### PR TITLE
feat:新增GazelleJSONAPI框架，并适配DIC和RED

### DIFF
--- a/resource/schemas/GazelleJSONAPI/config.json
+++ b/resource/schemas/GazelleJSONAPI/config.json
@@ -1,0 +1,62 @@
+{
+  "name": "GazelleJSONAPI",
+  "ver": "0.0.1",
+  "plugins": [{
+    "name": "种子列表",
+    "pages": ["/torrents.php"],
+    "scripts": ["/schemas/NexusPHP/common.js", "torrents.js"]
+  }],
+  "securityKeyFields": ["authkey", "torrent_pass"],
+  "searchEntryConfig": {
+    "page": "/ajax.php",
+    "resultType": "json",
+    "parseScriptFile": "/schemas/GazelleJSONAPI/getSearchResult.js",
+    "queryString": "action=browse&searchstr=$key$"
+  },
+  "searchEntry": [{
+    "name": "all",
+    "enabled": true
+  }],
+  "selectors": {
+    "userBaseInfo": {
+      "page": "/ajax.php?action=index",
+      "dataType": "json",
+      "fields": {
+        "id": {
+          "selector": ["response.id"]
+        },
+        "name": {
+          "selector": ["response.username"]
+        },
+        "messageCount": {
+          "selector": ["response.notifications.messages"]
+        },
+        "uploaded": {
+          "selector": ["response.userstats.uploaded"]
+        },
+        "downloaded": {
+          "selector": ["response.userstats.downloaded"]
+        },
+        "ratio": {
+          "selector": ["response.userstats.ratio"]
+        },
+        "levelName": {
+          "selector": ["response.userstats.class"]
+        }
+      }
+    },
+    "userExtendInfo": {
+      "page": "/ajax.php?action=user&id=$user.id$",
+      "dataType": "json",
+      "fields": {        
+        "joinTime": {
+          "selector": ["response.stats.joinedDate"],
+          "filters": ["dateTime(query).isValid()?dateTime(query).valueOf():query"]
+        },
+        "seeding": {
+          "selector": ["response.community.seeding"]
+        }
+      }
+    }
+  }
+}

--- a/resource/schemas/GazelleJSONAPI/config.json
+++ b/resource/schemas/GazelleJSONAPI/config.json
@@ -57,6 +57,18 @@
           "selector": ["response.community.seeding"]
         }
       }
+    },
+    "userSeedingTorrents": {
+      "page": "/torrents.php?type=seeding&userid=$user.id$",
+      "fields": {
+        "seedingSize": {
+          "selector": ["td.number_column.nobr"],
+          "filters": ["jQuery.map(query, (item)=>{return $(item).text();})", "_self.getTotalSize(query)"]
+        },
+        "bonus" : {
+          "value": null
+        }
+      }
     }
   }
 }

--- a/resource/schemas/GazelleJSONAPI/getSearchResult.js
+++ b/resource/schemas/GazelleJSONAPI/getSearchResult.js
@@ -57,13 +57,10 @@
                 url: `${site.url}torrents.php?action=download&id=${torrent.torrentId}&authkey=${authkey}&torrent_pass=${passkey}`,
                 size: parseFloat(torrent.size),
                 time: torrent.time,
-                author: "",
                 seeders: torrent.seeders,
                 leechers: torrent.leechers,
                 completed: torrent.snatches,
-                comments: 0,
                 site: site,
-                tags: group.tags,
                 entryName: options.entry.name,
                 category: group.releaseType
               }

--- a/resource/schemas/GazelleJSONAPI/getSearchResult.js
+++ b/resource/schemas/GazelleJSONAPI/getSearchResult.js
@@ -1,0 +1,108 @@
+(function (options) {
+  class Parser {
+    constructor() {
+      this.haveData = false;
+      this.categories = {};
+      if (/auth_form/.test(options.responseText)) {
+        options.status = ESearchResultParseStatus.needLogin;
+        return;
+      }
+      options.isLogged = true;
+      this.haveData = true;
+    }
+
+    /**
+     * 获取搜索结果
+     */
+
+    getResult() {
+      if (!this.haveData) {
+        return [];
+      }
+      let site = options.site;
+      let groups = options.page.response.results;
+      if (groups.length == 0) {
+        options.status = ESearchResultParseStatus.noTorrents;
+        return [];
+      }
+      let results = [];
+      let authkey = options.page.AuthKey;
+      let passkey = options.page.PassKey;
+      console.log("groups.length", groups.length);
+      try {
+        groups.forEach(group => {
+          if (group.hasOwnProperty("torrents")) {
+            let torrents = group.torrents;
+            torrents.forEach(torrent => {
+              let data = {
+                title: group.artist +
+                  " - " +
+                  group.groupName +
+                  " [" +
+                  group.groupYear +
+                  "] [" +
+                  group.releaseType +
+                  "]",
+                subTitle: torrent.format +
+                  " / " +
+                  torrent.encoding +
+                  " / " +
+                  torrent.media +
+                  (torrent.hasLog ? ` / Log(${torrent.logScore})` : "") +
+                  (torrent.hasCue ? " / Cue" : "") +
+                  (torrent.remastered ? ` / ${torrent.remasterYear}` : "") +
+                  (torrent.scene ? " / Scene" : "") +
+                  ((torrent.isFreeleech || torrent.isNeutralLeech || torrent.isPersonalFreeleech) ? " / Freeleech" : ""),
+                link: `${site.url}torrents.php?id=${group.groupId}&torrentid=${torrent.torrentId}`,
+                url: `${site.url}torrents.php?action=download&id=${torrent.torrentId}&authkey=${authkey}&torrent_pass=${passkey}`,
+                size: parseFloat(torrent.size),
+                time: torrent.time,
+                author: "",
+                seeders: torrent.seeders,
+                leechers: torrent.leechers,
+                completed: torrent.snatches,
+                comments: 0,
+                site: site,
+                tags: group.tags,
+                entryName: options.entry.name,
+                category: group.releaseType
+              }
+              results.push(data);
+            })
+          } else {
+            let data = {
+              title: group.groupName,
+              link: `${site.url}torrents.php?id=${group.groupId}&torrentid=${group.torrentId}`,
+              url: `${site.url}torrents.php?action=download&id=${group.torrentId}&authkey=${authkey}&torrent_pass=${passkey}`,
+              size: parseFloat(group.size),
+              time: group.groupTime,
+              author: "",
+              seeders: group.seeders,
+              leechers: group.leechers,
+              completed: group.snatches,
+              comments: 0,
+              site: site,
+              tags: group.tags,
+              entryName: options.entry.name,
+              category: group.category
+            }
+            results.push(data);
+          }
+        })
+        console.log("results.length", results.length);
+        if (results.length == 0) {
+          options.status = ESearchResultParseStatus.noTorrents;
+        }
+      } catch (error) {
+        console.log(error);
+        options.status = ESearchResultParseStatus.parseError;
+        options.errorMsg = error.stack;
+      }
+      return results;
+    }
+  }
+
+  let parser = new Parser(options);
+  options.results = parser.getResult();
+  console.log(options.results);
+})(options);

--- a/resource/schemas/GazelleJSONAPI/torrents.js
+++ b/resource/schemas/GazelleJSONAPI/torrents.js
@@ -1,0 +1,109 @@
+(function($) {
+  console.log("this is torrent.js");
+  class App extends window.NexusPHPCommon {
+    init() {
+      // super();
+      this.initButtons();
+      this.initFreeSpaceButton();
+      // 设置当前页面
+      PTService.pageApp = this;
+    }
+
+    /**
+     * 初始化按钮列表
+     */
+    initButtons() {
+      this.initListButtons();
+    }
+
+    /**
+     * 获取下载链接
+     */
+    getDownloadURLs() {
+      let links = $("a[title='Download']").toArray();
+      let siteURL = PTService.site.url;
+      if (siteURL.substr(-1) != "/") {
+        siteURL += "/";
+      }
+
+      if (links.length == 0) {
+        links = $("a[href*='torrents.php?action=download']").toArray();
+      }
+
+      if (links.length == 0) {
+        return this.t("getDownloadURLsFailed"); //"获取下载链接失败，未能正确定位到链接";
+      }
+
+      let urls = $.map(links, item => {
+        let link = $(item).attr("href");
+        if (link && link.substr(0, 4) != "http") {
+          link = siteURL + link;
+        }
+        return link;
+      });
+
+      return urls;
+    }
+
+    /**
+     * 确认大小是否超限
+     */
+    confirmWhenExceedSize() {
+      return this.confirmSize(
+        $("#torrent_table").find(
+          "td:contains('MB'),td:contains('GB'),td:contains('TB')"
+        )
+      );
+    }
+
+    /**
+     * 下载拖放的种子
+     * @param {*} url
+     * @param {*} callback
+     */
+    downloadFromDroper(data, callback) {
+      if (typeof data === "string") {
+        data = {
+          url: data,
+          title: ""
+        };
+      }
+
+      console.log(data);
+
+      if (!data.url) {
+        PTService.showNotice({
+          msg: this.t("invalidURL") //"无效的链接"
+        });
+        callback();
+        return;
+      }
+
+      let authkey = data.url.getQueryString("authkey");
+      let torrent_pass = data.url.getQueryString("torrent_pass");
+      // authkey=&torrent_pass
+      if (!authkey && !torrent_pass) {
+        PTService.showNotice({
+          msg: this.t("dropInvalidURL") //"无效的链接，请拖放下载链接"
+        });
+        callback();
+        return;
+      }
+
+      if (data.url.substr(0, 1) === "/") {
+        data.url = `${location.origin}${data.url}`;
+      } else if (data.url.substr(0, 4) !== "http") {
+        data.url = `${location.origin}/${data.url}`;
+      }
+
+      this.sendTorrentToDefaultClient(data)
+        .then(result => {
+          callback(result);
+        })
+        .catch(result => {
+          callback(result);
+        });
+    }
+  }
+  new App().init();
+})(jQuery);

--- a/resource/sites/alpharatio.cc/config.json
+++ b/resource/sites/alpharatio.cc/config.json
@@ -3,141 +3,162 @@
   "description": "0day",
   "url": "https://alpharatio.cc/",
   "icon": "https://alpharatio.cc/favicon.ico",
-  "tags": ["音乐", "0day"],
-  "schema": "Gazelle",
+  "tags": ["综合", "0day"],
+  "schema": "GazelleJSONAPI",
   "host": "alpharatio.cc",
-  "searchEntryConfig": {
-    "page": "/torrents.php",
-    "queryString": "searchstr=$key$&searchsubmit=1",
-    "resultType": "html",
-    "parseScriptFile": "/schemas/Gazelle/getSearchResult.js",
-    "resultSelector": "table.torrent_table:last > tbody > tr",
-    "area": [{
-      "name": "IMDB",
-      "keyAutoMatch": "^(tt\\d+)$",
-      "queryString": "taglist=$key$&searchsubmit=1"
-    }]
-  },
+  "collaborator": "enigamz",
   "searchEntry": [{
     "name": "all",
     "enabled": true
-  }],
-  "categories": [{
-    "entry": "*",
-    "result": "&filter_cat[$id$]=1",
-    "category": [{
-      "id": 1,
-      "name": "TvSD"
-    }, {
-      "id": 2,
-      "name": "TvHD"
-    }, {
-      "id": 3,
-      "name": "TvUHD"
-    }, {
-      "id": 4,
-      "name": "TvDVDRip"
-    }, {
-      "id": 5,
-      "name": "TvPackSD"
-    }, {
-      "id": 6,
-      "name": "TvPackHD"
-    }, {
-      "id": 7,
-      "name": "TvPackUHD"
-    }, {
-      "id": 8,
-      "name": "MovieSD"
-    }, {
-      "id": 9,
-      "name": "MovieHD"
-    }, {
-      "id": 10,
-      "name": "MovieUHD"
-    }, {
-      "id": 11,
-      "name": "MoviePackSD"
-    }, {
-      "id": 12,
-      "name": "MoviePackHD"
-    }, {
-      "id": 13,
-      "name": "MoviePackUHD"
-    }, {
-      "id": 14,
-      "name": "MovieXXX"
-    }, {
-      "id": 15,
-      "name": "Bluray"
-    }, {
-      "id": 16,
-      "name": "AnimeSD"
-    }, {
-      "id": 17,
-      "name": "AnimeHD"
-    }, {
-      "id": 18,
-      "name": "GamesPC"
-    }, {
-      "id": 19,
-      "name": "GamesxBox"
-    }, {
-      "id": 20,
-      "name": "GamesPS"
-    }, {
-      "id": 21,
-      "name": "GamesNin"
-    }, {
-      "id": 22,
-      "name": "AppsWindows"
-    }, {
-      "id": 23,
-      "name": "AppsMAC"
-    }, {
-      "id": 24,
-      "name": "AppsLinux"
-    }, {
-      "id": 25,
-      "name": "AppsMobile"
-    }, {
-      "id": 26,
-      "name": "0dayXXX"
-    }, {
-      "id": 27,
-      "name": "eBook"
-    }, {
-      "id": 28,
-      "name": "AudioBook"
-    }, {
-      "id": 29,
-      "name": "Music"
-    }, {
-      "id": 30,
-      "name": "Misc"
-    }]
-  }],
-  "selectors": {
-    "userExtendInfo": {
-      "merge": true,
-      "fields": {
-        "messageCount": {
-          "selector": ["div.alertbar > a[href='inbox.php']"],
-          "filters": ["query.text().match(/(\\d+)/)", "(query && query.length>=2)?parseInt(query[1]):0"]
-        }
-      }
-    },
-    "userSeedingTorrents": {
-      "page": "/ajax.php?action=community_stats&userid=$user.id$",
-      "dataType": "json",
-      "fields": {
-        "seeding": {
-          "selector": ["response.seeding"]
-        },
-        "seedingSize": {
-          "value": -1
-        }
-      }
-    }
-  }
+  },
+  {
+    "queryString": "filter_cat[1]=1",
+    "name": "TvSD",
+    "enabled": false
+  },
+  {
+    "queryString": "filter_cat[2]=1",
+    "name": "TvHD",
+    "enabled": false
+  },
+  {
+    "queryString": "filter_cat[3]=1",
+    "name": "TvUHD",
+    "enabled": false
+  },
+  {
+    "queryString": "filter_cat[4]=1",
+    "name": "TvDVDRip",
+    "enabled": false
+  },
+  {
+    "queryString": "filter_cat[5]=1",
+    "name": "TvPackSD",
+    "enabled": false
+  },
+  {
+    "queryString": "filter_cat[6]=1",
+    "name": "TvPackHD",
+    "enabled": false
+  },
+  {
+    "queryString": "filter_cat[7]=1",
+    "name": "TvPackUHD",
+    "enabled": false
+  },
+  {
+    "queryString": "filter_cat[8]=1",
+    "name": "MovieSD",
+    "enabled": false
+  },
+  {
+    "queryString": "filter_cat[9]=1",
+    "name": "MovieHD",
+    "enabled": false
+  },
+  {
+    "queryString": "filter_cat[10]=1",
+    "name": "MovieUHD",
+    "enabled": false
+  },
+  {
+    "queryString": "filter_cat[11]=1",
+    "name": "MoviePackSD",
+    "enabled": false
+  },
+  {
+    "queryString": "filter_cat[12]=1",
+    "name": "MoviePackHD",
+    "enabled": false
+  },
+  {
+    "queryString": "filter_cat[13]=1",
+    "name": "MoviePackUHD",
+    "enabled": false
+  },
+  {
+    "queryString": "filter_cat[14]=1",
+    "name": "MovieXXX",
+    "enabled": false
+  },
+  {
+    "queryString": "filter_cat[15]=1",
+    "name": " Bluray",
+    "enabled": false
+  },
+  {
+    "queryString": "filter_cat[16]=1",
+    "name": "AnimeSD",
+    "enabled": false
+  },
+  {
+    "queryString": "filter_cat[17]=1",
+    "name": "AnimeHD",
+    "enabled": false
+  },
+  {
+    "queryString": "filter_cat[18]=1",
+    "name": "GamesPC",
+    "enabled": false
+  },
+  {
+    "queryString": "filter_cat[19]=1",
+    "name": "GamesxBox",
+    "enabled": false
+  },
+  {
+    "queryString": "filter_cat[20]=1",
+    "name": "GamesPS",
+    "enabled": false
+  },
+  {
+    "queryString": "filter_cat[21]=1",
+    "name": "GamesNin",
+    "enabled": false
+  },
+  {
+    "queryString": "filter_cat[22]=1",
+    "name": "AppsWindows",
+    "enabled": false
+  },
+  {
+    "queryString": "filter_cat[23]=1",
+    "name": "AppsMAC",
+    "enabled": false
+  },
+  {
+    "queryString": "filter_cat[24]=1",
+    "name": "AppsLinux",
+    "enabled": false
+  },
+  {
+    "queryString": "filter_cat[25]=1",
+    "name": "AppsMobile",
+    "enabled": false
+  },
+  {
+    "queryString": "filter_cat[26]=1",
+    "name": "0dayXXX",
+    "enabled": false
+  },
+  {
+    "queryString": "filter_cat[27]=1",
+    "name": "eBook",
+    "enabled": false
+  },
+  {
+    "queryString": "filter_cat[28]=1",
+    "name": "AudioBook",
+    "enabled": false
+  },
+  {
+    "queryString": "filter_cat[29]=1",
+    "name": "Music",
+    "enabled": false
+  },
+  {
+    "queryString": "filter_cat[30]=1",
+    "name": "Misc",
+    "enabled": false
+  }]
 }

--- a/resource/sites/broadcasthe.net/config.json
+++ b/resource/sites/broadcasthe.net/config.json
@@ -1,10 +1,106 @@
 {
   "name": "BTN",
   "description": "著名剧集站点，又被戏称为鼻涕妞",
-  "url": "http://broadcasthe.net/",
-  "icon": "http://broadcasthe.net/favicon.ico",
-  "tags": ["剧集", "0day"],
+  "url": "https://broadcasthe.net/",
+  "icon": "https://broadcasthe.net/favicon.ico",
+  "tags": ["剧集"],
   "schema": "Gazelle",
   "host": "broadcasthe.net",
-  "collaborator": "ylxb2016"
+  "collaborator": "ylxb2016, enigmaz",
+  "searchEntryConfig": {
+    "page": "/torrents.php",
+    "resultType": "html",
+    "parseScriptFile": "getSearchResult.js",
+    "queryString": "searchstr=$key$"
+  },
+  "searchEntry": [
+    {
+      "name": "all",
+      "enabled": true
+    },
+    {
+      "queryString": "filter_cat[1]=1",
+      "name": "Episode",
+      "enabled": false
+    },
+    {
+      "queryString": "filter_cat[2]=1",
+      "name": "Season",
+      "enabled": false
+    }
+  ],
+  "categories": [
+    {
+      "entry": "*",
+      "result": "&filter_cat[$id$]=1",
+      "category": [
+        {
+          "id": 1,
+          "name": "Episode"
+        },
+        {
+          "id": 2,
+          "name": "Season"
+        }
+      ]
+    }
+  ],
+  "selectors": {
+    "userExtendInfo": {
+      "page": "/user.php?id=$user.id$",
+      "fields": {
+        "uploaded": {
+          "selector": "#section2 > div > div.statistics > div:nth-child(3) > ul > li:nth-child(1)",
+          "filters": [
+            "query.text().replace(/,/g,'').match(/Upload.+?([\\d.]+ ?[TGMK]?i?B)/)",
+            "(query && query.length>=2)?(query[1]).sizeToNumber():0"
+          ]
+        },
+        "downloaded": {
+          "selector": "#section2 > div > div.statistics > div:nth-child(3) > ul > li:nth-child(7)",
+          "filters": [
+            "query.text().replace(/,/g,'').match(/Downloaded.+?([\\d.]+ ?[TGMK]?i?B)/)",
+            "(query && query.length>=2)?(query[1]).sizeToNumber():0"
+          ]
+        },
+        "ratio": {
+          "value": null
+        },
+        "levelName": {
+          "selector": "#section2 > div > div.statistics > div:nth-child(1) > ul > li:nth-child(2)",
+          "filters": [
+            "query.text().match(/Class:.+?(.+)/)",
+            "(query && query.length>=2)?query[1]:''"
+          ]
+        },
+        "bonus": {
+          "selector": "#section2 > div > div.statistics > div:nth-child(1) > ul > li:nth-child(5) > a",
+          "filters": [
+            "query.text()"
+          ]
+        },
+        "joinTime": {
+          "selector": "#section2 > div > div.statistics > div:nth-child(1) > ul > li:nth-child(1) > span",
+          "filters": [
+            "query.attr('title')||query.text()",
+            "dateTime(query).isValid()?dateTime(query).valueOf():query"
+          ]
+        },
+        "seeding": {
+          "selector": "#section2 > div > div.statistics > div:nth-child(3) > ul > li:nth-child(4)",
+          "filters": [
+            "query.text().replace(/,/g,'').match(/Seeding:.+?(\\d+).+?/)",
+            "(query && query.length>=2)?(query[1]):0"
+          ]
+        },
+        "seedingSize": {
+          "selector": "#section2 > div > div.statistics > div:nth-child(3) > ul > li:nth-child(5)",
+          "filters": [
+            "query.text().replace(/,/g,'').match(/Seeding Size:.+?([\\d.]+ ?[TGMK]?i?B)/)",
+            "(query && query.length>=2)?(query[1]).sizeToNumber():0"
+          ]
+        }
+      }
+    }
+  }
 }

--- a/resource/sites/broadcasthe.net/getSearchResult.js
+++ b/resource/sites/broadcasthe.net/getSearchResult.js
@@ -1,0 +1,196 @@
+(function(options) {
+  class Parser {
+    constructor() {
+      this.haveData = false;
+      this.categories = {};
+      if (/auth_form/.test(options.responseText)) {
+        options.status = ESearchResultParseStatus.needLogin; //`[${options.site.name}]需要登录后再搜索`;
+        return;
+      }
+
+      options.isLogged = true;
+
+      if (
+        /没有种子|No [Tt]orrents?|Your search did not match anything|用准确的关键字重试/.test(
+          options.responseText
+        )
+      ) {
+        options.status = ESearchResultParseStatus.noTorrents; //`[${options.site.name}]没有搜索到相关的种子`;
+        return;
+      }
+
+      this.haveData = true;
+    }
+
+    /**
+     * 获取搜索结果
+     */
+    getResult() {
+      let site = options.site;
+      let results = [];
+      // 获取种子列表行
+      let rows = options.page.find(
+        options.resultSelector || "table.torrent_table:last > tbody > tr"
+      );
+      if (rows.length == 0) {
+        options.status = ESearchResultParseStatus.torrentTableIsEmpty; //`[${options.site.name}]没有定位到种子列表，或没有相关的种子`;
+        return results;
+      }
+      // 获取表头
+      let header = rows.eq(0).find("th,td");
+
+      // 用于定位每个字段所列的位置
+      let fieldIndex = {
+        time: -1,
+        size: -1,
+        seeders: -1,
+        leechers: -1,
+        completed: -1,
+        comments: -1,
+        author: -1
+      };
+
+      if (site.url.lastIndexOf("/") != site.url.length - 1) {
+        site.url += "/";
+      }
+
+      // 获取字段所在的列
+      for (let index = 0; index < header.length; index++) {
+        const cell = header.eq(index);
+
+        // 大小
+        if (cell.find("a[href*='order_by=size']").length) {
+          fieldIndex.size = index;
+          continue;
+        }
+
+        // 种子数
+        if (cell.find("a[href*='order_by=seeders']").length) {
+          fieldIndex.seeders = index;
+          continue;
+        }
+
+        // 下载数
+        if (cell.find("a[href*='order_by=leechers']").length) {
+          fieldIndex.leechers = index;
+          continue;
+        }
+
+        // 完成数
+        if (cell.find("a[href*='order_by=snatched']").length) {
+          fieldIndex.completed = index;
+          continue;
+        }
+      }
+
+      try {
+        // 遍历数据行
+        for (let index = 1; index < rows.length; index++) {
+          const row = rows.eq(index);
+          let cells = row.find(">td");
+
+          // 标题
+          let title = row.find("[style='float:none;']").first().attr("title");
+          
+          // 链接
+          let link = row.find("[title='View Torrent']").first().attr("href");
+          if (link && link.substr(0, 4) !== "http") {
+            link = `${site.url}${link}`;
+          }
+
+          // 获取下载链接
+          let url = row.find("[title='Download']").first().attr("href");
+          if (url.substr(0, 4) !== "http") {
+            url = `${site.url}${url}`;
+          }
+
+          // 分类
+          let category = row.find("a[href*='filter_cat']").children().first().attr("title");
+
+          // 时间
+          let timeStrMatch = row.find("div:contains('Added:')").text().match(/Added:(.+)ago/);
+          let timeStr = (timeStrMatch && timeStrMatch.length >=2) ? timeStrMatch[1].trim() : "";
+
+          let data = {
+            title,
+            link,
+            url,
+            size:
+              fieldIndex.size == -1
+                ? ""
+                : cells.eq(fieldIndex.size).text() || 0,
+            time: this.getTime(timeStr),
+            author:
+              fieldIndex.author == -1
+                ? ""
+                : cells.eq(fieldIndex.author).text() || "",
+            seeders:
+              fieldIndex.seeders == -1
+                ? ""
+                : cells.eq(fieldIndex.seeders).text() || 0,
+            leechers:
+              fieldIndex.leechers == -1
+                ? ""
+                : cells.eq(fieldIndex.leechers).text() || 0,
+            completed:
+              fieldIndex.completed == -1
+                ? ""
+                : cells.eq(fieldIndex.completed).text() || 0,
+            comments:
+              fieldIndex.comments == -1
+                ? ""
+                : cells.eq(fieldIndex.comments).text() || 0,
+            site,
+            entryName: options.entry.name,
+            category
+          };
+          results.push(data);
+        }
+        if (results.length == 0) {
+          options.status = ESearchResultParseStatus.noTorrents; //`[${options.site.name}]没有搜索到相关的种子`;
+        }
+      } catch (error) {
+        console.error(error);
+        options.status = ESearchResultParseStatus.parseError;
+        options.errorMsg = error.stack; //`[${options.site.name}]获取种子信息出错: ${error.stack}`;
+      }
+
+      return results;
+    }
+
+    getTime(timeStr) {
+      let timeRegex = timeStr.match(
+        /((\d+).+?(minute|hour|day|month|year)s?.+?and.+?)?(\d+).+?(minute|hour|day|month|year)s?/
+      );
+      let milliseconds = 0;
+      if (timeRegex) {
+        if (timeRegex[1] == undefined) {
+          milliseconds = this.getMilliseconds(timeRegex[4], timeRegex[5]);
+        } else {
+          milliseconds = this.getMilliseconds(timeRegex[2], timeRegex[3]) + this.getMilliseconds(timeRegex[4], timeRegex[5]);
+        }
+      }
+      let timeStamp = Date.now() - milliseconds;
+      let date = new Date(timeStamp);
+      return date.toISOString();
+    }
+
+    getMilliseconds(num, unit) {
+      let milliseconds = 0;
+      milliseconds = num*60*1000;
+      if(unit == "minute") {return milliseconds;}
+      milliseconds = milliseconds*60;
+      if(unit == "hour") {return milliseconds;}
+      milliseconds = milliseconds*24;
+      if(unit == "day") {return milliseconds;}
+      milliseconds = milliseconds*30;
+      if(unit == "month") {return milliseconds;}
+      milliseconds = milliseconds*12;
+      return milliseconds;
+    }
+  }
+
+  let parser = new Parser(options);
+  options.results = parser.getResult();
+  console.log(options.results);
+})(options);

--- a/resource/sites/dicmusic.club/config.json
+++ b/resource/sites/dicmusic.club/config.json
@@ -4,44 +4,20 @@
   "url": "https://dicmusic.club/",
   "icon": "https://dicmusic.club/favicon.ico",
   "tags": ["音乐"],
-  "schema": "Gazelle",
+  "schema": "GazelleJSONAPI",
   "host": "dicmusic.club",
-  "collaborator": "ylxb2016",
+  "collaborator": "ylxb2016, enigmaz",
   "selectors": {
-    "userExtendInfo": {
-      "page": "/user.php?id=$user.id$",
-      "fields": {
-        "uploaded": {
-          "selector": "div.box_userinfo_stats > ul.stats > li:contains('已上传: ')",
-          "filters": ["query.text().match(/已上传:.+?([\\d.]+ [TGMK]?i?B)/)", "(query && query.length>=2)?(query[1]).sizeToNumber():0"]
-        },
-        "downloaded": {
-          "selector": "div.box_userinfo_stats > ul.stats > li:contains('下载量: ')",
-          "filters": ["query.text().match(/下载量:.+?([\\d.]+ [TGMK]?i?B)/)", "(query && query.length>=2)?(query[1]).sizeToNumber():0"]
-        },
-        "levelName": {
-          "selector": "div.box_userinfo_personal > ul.stats > li:contains('等级: ')",
-          "filters": ["query.text().match(/等级:.+?(.+)/)", "(query && query.length>=2)?query[1]:''"]
-        },
-        "bonus": {
-          "selector": ["div.box_userinfo_stats > ul.stats > li:contains('积分: ')"],
-          "filters": ["query.text().replace(/,/g,'')", "query.match(/积分:.+?([\\d.]+)/)", "(query && query.length>=2)?query[1]:0"]
-        },
-        "joinTime": {
-          "selector": ["div.box_userinfo_stats > ul.stats > li:contains('注册时间: ') > span"],
-          "filters": ["query.attr('title')||query.text()", "dateTime(query).isValid()?dateTime(query).valueOf():query"]
-        }
-      }
-    },
     "userSeedingTorrents": {
-      "page": "/ajax.php?action=community_stats&userid=$user.id$",
-      "dataType": "json",
+      "page": "/torrents.php?type=seeding&userid=$user.id$",
       "fields": {
-        "seeding": {
-          "selector": ["response.seeding"]
-        },
         "seedingSize": {
-          "value": -1
+          "selector": ["td.td_size.number_column.nobr"],
+          "filters": ["jQuery.map(query, (item)=>{return $(item).text();})", "_self.getTotalSize(query)"]
+        },
+        "bonus" : {
+          "selector": ["[href='bonus.php']"],
+          "filters": ["query.text().replace(/,/g,'')", "query.match(/积分.+?\\(([\\d.]+)\\)/)", "(query && query.length>=2)?query[1]:0"]
         }
       }
     }

--- a/resource/sites/redacted.ch/config.json
+++ b/resource/sites/redacted.ch/config.json
@@ -4,7 +4,21 @@
   "url": "https://redacted.ch/",
   "icon": "https://redacted.ch/favicon.ico",
   "tags": ["音乐"],
-  "schema": "Gazelle",
+  "schema": "GazelleJSONAPI",
   "host": "redacted.ch",
-  "collaborator": "ylxb2016"
+  "collaborator": "ylxb2016, enigamz",
+  "selectors": {
+    "userSeedingTorrents": {
+      "page": "/torrents.php?type=seeding&userid=$user.id$",
+      "fields": {
+        "seedingSize": {
+          "selector": ["td.number_column.nobr"],
+          "filters": ["jQuery.map(query, (item)=>{return $(item).text();})", "_self.getTotalSize(query)"]
+        },
+        "bonus" : {
+          "value": null
+        }
+      }
+    }
+  }
 }

--- a/resource/sites/redacted.ch/config.json
+++ b/resource/sites/redacted.ch/config.json
@@ -7,18 +7,43 @@
   "schema": "GazelleJSONAPI",
   "host": "redacted.ch",
   "collaborator": "ylxb2016, enigamz",
-  "selectors": {
-    "userSeedingTorrents": {
-      "page": "/torrents.php?type=seeding&userid=$user.id$",
-      "fields": {
-        "seedingSize": {
-          "selector": ["td.number_column.nobr"],
-          "filters": ["jQuery.map(query, (item)=>{return $(item).text();})", "_self.getTotalSize(query)"]
-        },
-        "bonus" : {
-          "value": null
-        }
-      }
-    }
-  }
+  "searchEntry": [{
+    "name": "all",
+    "enabled": true
+  },
+  {
+    "queryString": "filter_cat[1]=1",
+    "name": "Music",
+    "enabled": false
+  },
+  {
+    "queryString": "filter_cat[2]=1",
+    "name": "Applications",
+    "enabled": false
+  },
+  {
+    "queryString": "filter_cat[3]=1",
+    "name": "E-Books",
+    "enabled": false
+  },
+  {
+    "queryString": "filter_cat[4]=1",
+    "name": "Audiobooks",
+    "enabled": false
+  },
+  {
+    "queryString": "filter_cat[5]=1",
+    "name": "E-Learning Videos",
+    "enabled": false
+  },
+  {
+    "queryString": "filter_cat[6]=1",
+    "name": "Comedy",
+    "enabled": false
+  },
+  {
+    "queryString": "filter_cat[7]=1",
+    "name": "Comics",
+    "enabled": false
+  }]
 }

--- a/resource/sites/uhdbits.org/config.json
+++ b/resource/sites/uhdbits.org/config.json
@@ -1,8 +1,65 @@
 {
   "name":"UHDBits",
+  "description": "HD",
   "icon":"https://uhdbits.org/favicon.ico",
-  "schema":"Gazelle",
-  "tags":["影视","综合"],
+  "schema":"GazelleJSONAPI",
+  "tags":["影视"],
   "url":"https://uhdbits.org/",
-  "collaborator": "bimzcy"
+  "collaborator": "bimzcy, enigamz",
+  "searchEntryConfig": {
+    "page": "/torrents.php",
+    "resultType": "html",
+    "parseScriptFile": "getSearchResult.js",
+    "queryString": "searchstr=$key$&group_results=0&searchsubmit=1"
+  },
+  "searchEntry": [{
+    "name": "all",
+    "enabled": true
+  },
+  {
+    "queryString": "filter_cat[1]=1",
+    "name": "Movie",
+    "enabled": false
+  },
+  {
+    "queryString": "filter_cat[2]=1",
+    "name": "Music",
+    "enabled": false
+  },
+  {
+    "queryString": "filter_cat[3]=1",
+    "name": "TV",
+    "enabled": false
+  }],
+  "categories": [{
+    "entry": "*",
+    "result": "&filter_cat[$id$]=1",
+    "category": [{
+      "id": 1,
+      "name": "Movie"
+    },
+    {
+      "id": 2,
+      "name": "Music"
+    },
+    {
+      "id": 3,
+      "name": "TV"
+    }]
+  }],
+  "selectors": {
+    "userSeedingTorrents": {
+      "page": "/torrents.php?type=seeding&userid=$user.id$",
+      "fields": {
+        "seedingSize": {
+          "selector": ["td.number_column.nobr"],
+          "filters": ["jQuery.map(query, (item)=>{return $(item).text();})", "_self.getTotalSize(query)"]
+        },
+        "bonus" : {
+          "selector": ["[href='bonus.php']+span"],
+          "filters": ["query.text()"]
+        }
+      }
+    }
+  }
 }

--- a/resource/sites/uhdbits.org/config.json
+++ b/resource/sites/uhdbits.org/config.json
@@ -10,7 +10,13 @@
     "page": "/torrents.php",
     "resultType": "html",
     "parseScriptFile": "getSearchResult.js",
-    "queryString": "searchstr=$key$&group_results=0&searchsubmit=1"
+    "queryString": "searchstr=$key$&group_results=0&searchsubmit=1",
+    "area": [{
+      "name": "IMDB",
+      "keyAutoMatch": "^(tt\\d+)$",
+      "replaceKey": ["tt", ""],
+      "queryString": "imdbid=$key$&group_results=0&searchsubmit=1"
+    }]
   },
   "searchEntry": [{
     "name": "all",

--- a/resource/sites/uhdbits.org/getSearchResult.js
+++ b/resource/sites/uhdbits.org/getSearchResult.js
@@ -1,0 +1,247 @@
+if (!"".getQueryString) {
+  String.prototype.getQueryString = function(name, split) {
+    if (split == undefined) split = "&";
+    var reg = new RegExp(
+        "(^|" + split + "|\\?)" + name + "=([^" + split + "]*)(" + split + "|$)"
+      ),
+      r;
+    if ((r = this.match(reg))) return decodeURI(r[2]);
+    return null;
+  };
+}
+
+(function(options) {
+  class Parser {
+    constructor() {
+      this.haveData = false;
+      this.categories = {};
+      if (/auth_form/.test(options.responseText)) {
+        options.status = ESearchResultParseStatus.needLogin; //`[${options.site.name}]需要登录后再搜索`;
+        return;
+      }
+
+      options.isLogged = true;
+
+      if (
+        /没有种子|No [Tt]orrents?|Your search did not match anything|用准确的关键字重试/.test(
+          options.responseText
+        )
+      ) {
+        options.status = ESearchResultParseStatus.noTorrents; //`[${options.site.name}]没有搜索到相关的种子`;
+        return;
+      }
+
+      this.haveData = true;
+    }
+
+    /**
+     * 获取搜索结果
+     */
+    getResult() {
+      let site = options.site;
+      let results = [];
+      // 获取种子列表行
+      let rows = options.page.find(
+        options.resultSelector || "table.torrent_table:last > tbody > tr"
+      );
+      if (rows.length == 0) {
+        options.status = ESearchResultParseStatus.torrentTableIsEmpty; //`[${options.site.name}]没有定位到种子列表，或没有相关的种子`;
+        return results;
+      }
+      // 获取表头
+      let header = rows.eq(0).find("th,td");
+
+      // 用于定位每个字段所列的位置
+      let fieldIndex = {
+        time: -1,
+        size: -1,
+        seeders: -1,
+        leechers: -1,
+        completed: -1,
+        comments: -1,
+        author: -1
+      };
+
+      if (site.url.lastIndexOf("/") != site.url.length - 1) {
+        site.url += "/";
+      }
+
+      // 获取字段所在的列
+      for (let index = 0; index < header.length; index++) {
+        const cell = header.eq(index);
+
+        // 发布时间
+        if (cell.find("a[href*='order_by=time']").length) {
+          fieldIndex.time = index;
+          continue;
+        }
+
+        // 大小
+        if (cell.find("a[href*='order_by=size']").length) {
+          fieldIndex.size = index;
+          continue;
+        }
+
+        // 种子数
+        if (cell.find("a[href*='order_by=seeders']").length) {
+          fieldIndex.seeders = index;
+          continue;
+        }
+
+        // 下载数
+        if (cell.find("a[href*='order_by=leechers']").length) {
+          fieldIndex.leechers = index;
+          continue;
+        }
+
+        // 完成数
+        if (cell.find("a[href*='order_by=snatched']").length) {
+          fieldIndex.completed = index;
+          continue;
+        }
+      }
+
+      try {
+        // 遍历数据行
+        for (let index = 1; index < rows.length; index++) {
+          const row = rows.eq(index);
+          let cells = row.find(">td");
+
+          let title = row.find("a[href*='torrents.php?id=']").first();
+          if (title.length == 0) {
+            continue;
+          }
+
+          let subTitle = row.find("div.torrent_info").first();
+
+          let link = title.attr("href");
+          if (link && link.substr(0, 4) !== "http") {
+            link = `${site.url}${link}`;
+          }
+
+          // 获取下载链接
+          let url = row
+            .find("a[href*='torrents.php?action=download'][title='Download']")
+            .first();
+
+          if (url.length == 0) {
+            continue;
+          }
+
+          url = url.attr("href");
+
+          if (url.substr(0, 4) !== "http") {
+            url = `${site.url}${url}`;
+          }
+
+          let time =
+            fieldIndex.time == -1
+              ? ""
+              : cells
+                  .eq(fieldIndex.time)
+                  .find("span[title],time[title]")
+                  .attr("title") ||
+                cells.eq(fieldIndex.time).text() ||
+                "";
+          if (time) {
+            time += ":00";
+          }
+
+          let data = {
+            title: title.text(),
+            subTitle: subTitle.text(),
+            link,
+            url: url,
+            size: cells.eq(fieldIndex.size).html() || 0,
+            time: time,
+            author:
+              fieldIndex.author == -1
+                ? ""
+                : cells.eq(fieldIndex.author).text() || "",
+            seeders:
+              fieldIndex.seeders == -1
+                ? ""
+                : cells.eq(fieldIndex.seeders).text() || 0,
+            leechers:
+              fieldIndex.leechers == -1
+                ? ""
+                : cells.eq(fieldIndex.leechers).text() || 0,
+            completed:
+              fieldIndex.completed == -1
+                ? ""
+                : cells.eq(fieldIndex.completed).text() || 0,
+            comments:
+              fieldIndex.comments == -1
+                ? ""
+                : cells.eq(fieldIndex.comments).text() || 0,
+            site: site,
+            entryName: options.entry.name,
+            category: this.getCategory(cells.find("a[href*='filter_cat']"))
+          };
+          results.push(data);
+        }
+        if (results.length == 0) {
+          options.status = ESearchResultParseStatus.noTorrents; //`[${options.site.name}]没有搜索到相关的种子`;
+        }
+      } catch (error) {
+        console.error(error);
+        options.status = ESearchResultParseStatus.parseError;
+        options.errorMsg = error.stack; //`[${options.site.name}]获取种子信息出错: ${error.stack}`;
+      }
+
+      return results;
+    }
+
+    /**
+     * 获取分类
+     * @param {*} link 当前列
+     */
+    getCategory(link) {
+      if (link.length == 0) {
+        return null;
+      }
+
+      let result = {
+        name: "",
+        link: ""
+      };
+
+      result.link = link.attr("href");
+      let id = result.link.match(/filter_cat\[(\d+)\]/)[1];
+      if (result.link.substr(0, 4) !== "http") {
+        result.link = options.site.url + result.link;
+      }
+
+      result.name = link.text().trim();
+
+      if (!result.name) {
+        result.name = this.getCategoryName(id);
+      }
+      return result;
+    }
+
+    getCategoryName(id) {
+      if ($.isEmptyObject(this.categories)) {
+        let cells = options.page.find(".cat_list:first").find("td");
+        cells.each((i, dom) => {
+          let id = $(dom)
+            .find("input")
+            .attr("id")
+            .replace("cat_", "");
+          let name = $(dom)
+            .find("label")
+            .text();
+          if (id) {
+            this.categories[id] = name;
+          }
+        });
+      }
+
+      return this.categories ? this.categories[id] : "";
+    }
+  }
+
+  let parser = new Parser(options);
+  options.results = parser.getResult();
+  console.log(options.results);
+})(options);


### PR DESCRIPTION
`feat:新增GazelleJSONAPI框架，并适配DIC和RED`
* 根据[JSON-API-Documentation](https://github.com/WhatCD/Gazelle/wiki/JSON-API-Documentation)新增GazelleJSONAPI框架。
* 目前适配了两个音乐站点DIC和RED，并且调整好了用户数据的采集。

`fix:修正了GazelleJSONAPI框架，并适配了DIC/RED/AR/UHD`
* 将用户数据做种体积加入到GazelleJSONAPI框架通用模块内
* 删除了部分无用的种子词条data属性，从而避免了一处显示bug
* 根据GazelleJSONAPI框架适配了DIC/RED/AR/UHD
* 增加了适配网站RED/AR/UHD的搜索分类
* UHD的种子页面采取原有的html解析方式，增加了副标题的显示

GazelleJSONAPI框架的优缺点阐述
优点：
* Gazelle原生API，对于支持此API的网站，无需做过多的配置就能轻松适配
* 基于JSON解析的代码相对html格式简单清晰

缺点：
* 原生格式仅对音乐站点支持较好例如RED/DIC，对于一些轻微改版的网站支持一般，例如UHD，缺失一定信息
* 许多基于Gazelle早期版本的网站，或者Gazelle fork版本的网站都不支持此API


