### PR TITLE
优化NBL/JpopSuki搜索结果中标题显示

### DIFF
--- a/resource/sites/jpopsuki.eu/getSearchResult.js
+++ b/resource/sites/jpopsuki.eu/getSearchResult.js
@@ -136,7 +136,7 @@ if (!"".getQueryString) {
           }
 
           title = title.parent();
-          title.find(">span, div.tags").remove();
+          title.find(">span, div.tags, a[title='View Comments']").remove();
           let time =
             fieldIndex.time == -1
               ? ""
@@ -148,7 +148,7 @@ if (!"".getQueryString) {
           }
 
           let data = {
-            title: title.text(),
+            title: title.text().trim().replace("()",""),
             link,
             url: url,
             size: cells.eq(fieldIndex.size).html() || 0,

--- a/resource/sites/nebulance.io/getSearchResult.js
+++ b/resource/sites/nebulance.io/getSearchResult.js
@@ -132,8 +132,6 @@ if (!"".getQueryString) {
             url = `${site.url}${url}`;
           }
 
-          title = title.parent();
-          title.find(">script, div.tags,>div").remove();
           let time =
             fieldIndex.time == -1
               ? ""
@@ -145,7 +143,7 @@ if (!"".getQueryString) {
           }
 
           let data = {
-            title: title.text(),
+            title: title.attr("data-src"),
             link,
             url: url,
             size: cells.eq(fieldIndex.size).find("div").first().text().replace(/,/g,'').trim() || 0,


### PR DESCRIPTION
- fix: 优化Nebulance和JpopSuki搜索结果中标题显示
  - 将Neblance标题显示调整为种子文件/文件夹标题，原group标题不能反映文件信息；
  - 如种子含有评论，JpopSuki原返回标题末尾会带有如(2)的标记，此为评论数，已调整去除。
