### PR TITLE
fix: 修复 HDU 魔力值获取异常的Bug

### DIFF
--- a/resource/sites/pt.hdupt.com/config.json
+++ b/resource/sites/pt.hdupt.com/config.json
@@ -115,7 +115,7 @@
       "fields": {
         "bonus": {
           "selector": ["td.rowhead:contains('魔力值') + td"],
-          "filters": ["query.text().replace(/,/g,'').match(/\\(([\\d.]+)/)", "(query && query.length>=2)?parseFloat(query[1]):0"]
+          "filters": ["query.is(\":contains('魔力值:')\")?query.text().replace(/,/g,'').match(/魔力值.+?([\\d.]+)/)[1]:query.text().replace(/,/g,'')", "parseFloat(query)"]
         }
       }
     }


### PR DESCRIPTION
其实并不需要修改filters，原来出现问题的原因目测是匹配了两个selector（大概，我并没有捐赠魔力所以并没法复现），所以只要把selector修改一下就ok了

Closes #330 