### PR TITLE
fix: 站点烧包、SSD新信息获取以及tl做种体积的调整

### DIFF
--- a/resource/sites/ptsbao.club/config.json
+++ b/resource/sites/ptsbao.club/config.json
@@ -8,6 +8,15 @@
   "host": "ptsbao.club",
   "collaborator": "laizony, ted423",
   "selectors": {
+    "userBaseInfo": {
+      "merge": true,
+      "fields": {
+        "messageCount": {
+          "selector": ["td[style*='background: indigo'] a[href*='messages.php']"],
+          "filters": ["query.text().match(/(\\d+)/)", "(query && query.length>=2)?parseInt(query[1]):0"]
+        }
+      }
+    },
     "userExtendInfo": {
       "merge": true,
       "fields": {

--- a/resource/sites/springsunday.net/config.json
+++ b/resource/sites/springsunday.net/config.json
@@ -120,5 +120,16 @@
         "filters": ["query.is('.uploading') ? 2 : query.is('.downloading') ? 1: null"]
       }
     }
+  },
+  "selectors": {
+    "userBaseInfo": {
+      "merge": true,
+      "fields": {
+        "messageCount": {
+          "selector": ["a[href*='messages.php'][style*='background: red']"],
+          "filters": ["query.text().match(/(\\d+)/)", "(query && query.length>=2)?parseInt(query[1]):0"]
+        }
+      }
+    }
   }
 }

--- a/resource/sites/www.torrentleech.org/getUserSeedingTorrents.js
+++ b/resource/sites/www.torrentleech.org/getUserSeedingTorrents.js
@@ -39,9 +39,9 @@
         datas.forEach(item => {
           // item[7] 是否已完成
           // item[8] 活动状态
-          if (item[7] == 1 && item[8] == "Yes") {
+          if (item[7] >= 1 && item[8] == "Yes") {
             results.seeding++;
-            results.seedingSize += item[3].sizeToNumber();
+            results.seedingSize += item[1].replace('<span class=\"torrent_name2\">',"").replace('</span>',"").sizeToNumber();
           }
         });
       }


### PR DESCRIPTION
tl:https://github.com/ronggang/PT-Plugin-Plus/issues/314
烧包更改了新信息的调幅颜色为indigo，导致匹配失败
SSD没有外层的t导致匹配失败