### PR TITLE
fix: 修复 `NPUBits` 无法正确获得种子链接的Bug

### DIFF
--- a/resource/schemas/NexusPHP/details.js
+++ b/resource/schemas/NexusPHP/details.js
@@ -13,6 +13,12 @@
       this.initDetailButtons();
 
       let sayThanksButton = $("input#saythanks:not(:disabled)");
+
+      // NPUBits 修改部分
+      if (sayThanksButton.length === 0) {
+        sayThanksButton = $("button.saythanks:not(:disabled)");
+      }
+
       if (sayThanksButton.length) {
         // 说谢谢
         PTService.addButton({
@@ -52,6 +58,16 @@
             $("td.rowfollow:contains('&passkey='):last").text() ||
             $("a[href*='download'][href*='?id']:first").attr("href") ||
             $("a[href*='download.php?']:first").attr("href");
+        }
+
+        // NPUBits 修改部分
+        // 如果链接地址以 javascript: 开头，则使用正则提取实际种子链接
+        if (url && url.substr(0, 11) === "javascript:") {
+          let reg = /https?:\/\/[-A-Za-z0-9+&@#/%?=~_|!:,.;]+[-A-Za-z0-9+&@#/%=~_|]/g;
+          let urls = url.match(reg);
+          if (urls.length > 0) {
+            url = urls[0];
+          }
         }
 
         // 如果链接地址中不包含passkey，且站点已配置 passkey 信息


### PR DESCRIPTION
fix: 修复 `NPUBits` 无法正确获得种子链接的Bug (Fix #146)
fix: 修复 `NPUBits` 缺失感谢发布者按钮的Bug

为 `NPUBits` 存在的特殊情况进行了条件判断，理论上不会影响其他PT站的正常工作。