### PR TITLE
一些维护

### DIFF
--- a/resource/sites/avgv.cc/config.json
+++ b/resource/sites/avgv.cc/config.json
@@ -6,5 +6,22 @@
   "description": "新加坡华人PT站，很有特色。",
   "tags": ["成人", "AV", "GAY", "LES"],
   "host": "avgv.cc",
-  "collaborator": "xiazhou8"
+  "collaborator": "xiazhou8",
+  "searchEntryConfig": {
+    "fieldSelector": {
+      "progress": {
+        "selector": ["div.probar_b1, div.probar_b2, div.probar_b3"],
+        "filters": ["query.attr('style')||''", "query.match(/width:([ \\d.]+)%/)", "(query && query.length>=2)?query[1]:null"]
+
+      },
+      "status": {
+        "selector": ["img[src='pic/ZZ.png']","div.probar_b1", "img[src='pic/WWC.png']"],
+        "switchFilters": [
+          ["2"],
+          ["1"],
+          ["255"]
+        ]
+      }
+    }
+  }
 }

--- a/resource/sites/chdbits.co/config.json
+++ b/resource/sites/chdbits.co/config.json
@@ -98,6 +98,25 @@
       "enabled": false
     }
   ],
+  "torrentTagSelectors": [{
+    "name": "Free",
+    "selector": "img.pro_free"
+  }, {
+    "name": "2xFree",
+    "selector": "img.pro_free2up"
+  }, {
+    "name": "2xUp",
+    "selector": "img.pro_2up"
+  }, {
+    "name": "2x50%",
+    "selector": "img.pro_50pctdown2up"
+  }, {
+    "name": "30%",
+    "selector": "img.pro_30pctdown"
+  }, {
+    "name": "50%",
+    "selector": "img.pro_50pctdown"
+  }],
   "searchEntryConfig": {
 	"merge": true,
     "fieldSelector": {

--- a/resource/sites/hd-torrents.org/config.json
+++ b/resource/sites/hd-torrents.org/config.json
@@ -63,13 +63,13 @@
     "name": "Free",
     "selector": "img[src*='free.png']"
   }, {
-    "name": "25%",
+    "name": "75%",
     "selector": "img[src*='25.png']"
   }, {
     "name": "50%",
     "selector": "img[src*='50.png']"
   }, {
-    "name": "75%",
+    "name": "25%",
     "selector": "img[src*='75.png']"
   }],
   "selectors": {

--- a/resource/sites/hd-torrents.org/config.json
+++ b/resource/sites/hd-torrents.org/config.json
@@ -29,7 +29,7 @@
       },
       "dataCacheTime": 60
     },
-    "queryString": "csrfToken=$beforeSearchData.csrfToken$&search=$key$",
+    "queryString": "csrfToken=$beforeSearchData.csrfToken$&search=$key$&active=0",
     "area": [{
       "name": "标题",
       "appendQueryString": "&options=0"

--- a/resource/sites/jpopsuki.eu/config.json
+++ b/resource/sites/jpopsuki.eu/config.json
@@ -18,6 +18,10 @@
     "resultSelector": "table.torrent_table:last > tbody > tr",
     "enabled": true
   }],
+  "torrentTagSelectors": [{
+    "name": "Free",
+    "selector": "strong:contains('Freeleech!')"
+  }],
   "categories": [{
     "entry": "*",
     "result": "&filter_cat[$id$]=1",

--- a/resource/sites/jpopsuki.eu/getSearchResult.js
+++ b/resource/sites/jpopsuki.eu/getSearchResult.js
@@ -10,7 +10,7 @@ if (!"".getQueryString) {
   };
 }
 
-(function(options) {
+(function(options, Searcher) {
   class Parser {
     constructor() {
       this.haveData = false;
@@ -209,6 +209,7 @@ if (!"".getQueryString) {
               fieldIndex.comments == -1
                 ? ""
                 : cells.eq(fieldIndex.comments).text() || 0,
+            tags: Searcher.getRowTags(site, row),
             site: site,
             category:
               fieldIndex.category == -1
@@ -258,4 +259,4 @@ if (!"".getQueryString) {
   let parser = new Parser(options);
   options.results = parser.getResult();
   console.log(options.results);
-})(options);
+})(options, options.searcher);

--- a/resource/sites/pterclub.com/config.json
+++ b/resource/sites/pterclub.com/config.json
@@ -18,7 +18,7 @@
       },
       "subTitle": {
         "selector": ["a[href*='details.php?id='][title]:first"],
-        "filters": ["query.parent().find('a, b, div').replaceWith(null).end().text().trim()"]
+        "filters": ["$(query.parent()[0].lastChild).text().trim()"]
       },
       "progress": {
         "selector": [".progbargreen", ".progbarred + .progbarrest", ".progbarred", ".progbarrest", ""],

--- a/resource/sites/tjupt.org/config.json
+++ b/resource/sites/tjupt.org/config.json
@@ -151,5 +151,6 @@
         }
       }
     }
-  }
+  },
+  "cdn": ["https://www.tjupt.org/"]
 }

--- a/resource/sites/uhdbits.org/getSearchResult.js
+++ b/resource/sites/uhdbits.org/getSearchResult.js
@@ -10,7 +10,7 @@ if (!"".getQueryString) {
   };
 }
 
-(function(options) {
+(function(options, Searcher) {
   class Parser {
     constructor() {
       this.haveData = false;
@@ -113,8 +113,8 @@ if (!"".getQueryString) {
           }
 
           let data = {
-            title: title.text(),
-            subTitle: subTitle.text(),
+            title: title.text() + ' / ' +subTitle.text(),
+            //subTitle: subTitle.text(),
             link,
             url: url,
             size: cells.eq(fieldIndex.size).html() || 0,
@@ -139,6 +139,7 @@ if (!"".getQueryString) {
               fieldIndex.comments == -1
                 ? ""
                 : cells.eq(fieldIndex.comments).text() || 0,
+            tags: this.getTags(row),
             site: site,
             entryName: options.entry.name,
             category: this.getCategory(cells.find("a[href*='filter_cat']"))
@@ -185,6 +186,47 @@ if (!"".getQueryString) {
       return result;
     }
 
+
+    getTags(row){
+        var query = row.find("strong:contains('Free'), strong:contains('2x'), strong:contains('%')");
+        var BASE_TAG_COLORS = {
+          // 免费下载
+          Free: "blue",
+          // 免费下载 + 2x 上传
+          "2xFree": "green",
+          // 2x 上传
+          "2xUp": "lime",
+          // 2x 上传 + 50% 下载
+          "2x50%": "light-green",
+          // 25% 下载
+          "25%": "purple",
+          // 30% 下载
+          "30%": "indigo",
+          // 35% 下载
+          "35%": "indigo darken-3",
+          // 50% 下载
+          "50%": "orange",
+          // 70% 下载
+          "70%": "blue-grey",
+          // 75% 下载
+          "75%": "lime darken-3",
+          // 仅 VIP 可下载
+          VIP: "orange darken-2",
+          // 禁止转载
+          "⛔️": "deep-orange darken-1"
+        };
+        if(query.length > 0) {
+            query = query.text().replace(' ','').replace('↓','');
+            var result = [{
+	            name: query,
+	            color: BASE_TAG_COLORS[query]
+            }]
+            return result;
+        }
+    }
+
+    
+
     getCategoryName(id) {
       if ($.isEmptyObject(this.categories)) {
         let cells = options.page.find(".cat_list:first").find("td");
@@ -209,4 +251,4 @@ if (!"".getQueryString) {
   let parser = new Parser(options);
   options.results = parser.getResult();
   console.log(options.results);
-})(options);
+})(options, Searcher);

--- a/resource/sites/www.hdarea.co/config.json
+++ b/resource/sites/www.hdarea.co/config.json
@@ -200,5 +200,16 @@
         "name": "HQ Audio"
       }
     ]
-  }]
+  }],
+  "selectors": {
+    "/details.php": {
+      "merge": true,
+      "fields": {
+        "downloadURL": {
+          "selector": ["td.rowfollow:contains('&passkey='):last"],
+          "filters": ["query[0].childNodes[0].textContent"]
+        }
+      }
+    }
+  }
 }

--- a/resource/sites/www.torrentleech.org/getSearchResult.js
+++ b/resource/sites/www.torrentleech.org/getSearchResult.js
@@ -1,4 +1,4 @@
-(function(options) {
+(function(options, Searcher) {
   class Parser {
     constructor() {
       this.haveData = false;
@@ -42,7 +42,7 @@
               completed: item.completed,
               comments: item.numComments,
               site: site,
-              tags: [],
+              tags: this.getTags(item),
               entryName: options.entry.name,
               category: options.searcher.getCategoryById(
                 site,
@@ -64,9 +64,17 @@
       }
       return results;
     }
+    getTags(item) {
+	  var tag = [{
+	    name: "free",
+        color: "blue"
+	  }]
+      if(item.tags.indexOf("FREELEECH")>-1)return tag;
+    }
   }
+
 
   let parser = new Parser(options);
   options.results = parser.getResult();
   console.log(options.results);
-})(options);
+})(options, Searcher);


### PR DESCRIPTION
- HDA https://github.com/ronggang/PT-Plugin-Plus/issues/486

- 核弹头
  - 搜索包括死种
  - 标签修正，其标签是-25%，描述是count 75% download

- jpop 支持Free标签

- 岛 https://github.com/ronggang/PT-Plugin-Plus/issues/484

- UHD https://github.com/ronggang/PT-Plugin-Plus/issues/433 并且标题显示方式有更新
因为UHD 搜索结果只有一个英文名，副标题是详细信息包括压制者都不显眼
![image](https://user-images.githubusercontent.com/7042766/79050961-07ee8c00-7c60-11ea-8785-4dfc3b178413.png)

- TL https://github.com/ronggang/PT-Plugin-Plus/issues/483

- 猫站 https://github.com/ronggang/PT-Plugin-Plus/issues/424
- 北洋 https://github.com/ronggang/PT-Plugin-Plus/issues/492
- 爱薇 搜索支持种子状态信息
