### PR TITLE
fix:修正葡萄的种子发布时间

### DIFF
--- a/resource/schemas/NexusPHP/getSearchResult.js
+++ b/resource/schemas/NexusPHP/getSearchResult.js
@@ -277,7 +277,40 @@
           .html(cell.html().replace("<br>", " "))
           .text();
       }
+      if (options.site.host === "pt.sjtu.edu.cn") {
+        time = Date.now() - this._parseTime(time)
+        time = new Date(time).toLocaleString("zh-CN", {hour12: false}).replace(/\//g,'-')
+      }
       return time || "";
+    }
+
+    _parseTime (timeString) {
+      const timeMatch = timeString.match(/\d+[分时天月年]/g)
+      let length = 0
+      timeMatch.forEach(time => {
+        const timeMatch = time.match(/(\d+)([分时天月年])/)
+        const number = parseInt(timeMatch[1])
+        const unit = timeMatch[2]
+        switch (true) {
+          case unit === '分':
+            length += number
+            break
+          case unit === '时':
+            length += number * 60
+            break
+          case unit === '天':
+            length += number * 60 * 24
+            break
+          case unit === '月':
+            length += number * 60 * 24 * 30
+            break
+          case unit === '年':
+            length += number * 60 * 24 * 365
+            break
+          default:
+        }
+      })
+      return length * 60 * 1000
     }
 
     /**


### PR DESCRIPTION
fix:修正葡萄的种子发布时间

之前葡萄的发布时间显示为"xx天xx小时"，现在通过粗略计算转换成与其他站点一致的时间显示。方便排序。

![image](https://user-images.githubusercontent.com/52339016/79822703-6801d280-83c4-11ea-9ed3-238d9cbf422c.png)
