### PR TITLE
fix:葡萄种子上传时间在两种模式下都能用

### DIFF
--- a/resource/schemas/NexusPHP/getSearchResult.js
+++ b/resource/schemas/NexusPHP/getSearchResult.js
@@ -278,8 +278,10 @@
           .text();
       }
       if (options.site.host === "pt.sjtu.edu.cn") {
-        time = Date.now() - this._parseTime(time)
-        time = new Date(time).toLocaleString("zh-CN", {hour12: false}).replace(/\//g,'-')
+        if (time.match(/\d+[分时天月年]/g)) {
+          time = Date.now() - this._parseTime(time)
+          time = new Date(time).toLocaleString("zh-CN", {hour12: false}).replace(/\//g,'-')
+        }
       }
       return time || "";
     }


### PR DESCRIPTION
fix:葡萄种子上传时间在两种模式下都能用。
之前我并不清楚葡萄的网站设置可以调整上传时间的显示方式。
上一个pr
https://github.com/ronggang/PT-Plugin-Plus/pull/499#issue-406418160
会造成已经设置了葡萄的网站时间显示类型为发生时间的用户出现解析错误的情况，现修正。

设置'发生时间'解析出的时间更精确。要么revert掉上一个pr，要么加上现在这个，保证两种网站设置不冲突。