### PR TITLE
fix(HD4FANS): 修复错误的标记2xFree的问题，完善搜索入口和进度条

### DIFF
--- a/resource/sites/pt.hd4fans.org/config.json
+++ b/resource/sites/pt.hd4fans.org/config.json
@@ -4,7 +4,143 @@
   "schema": "NexusPHP",
   "url": "https://pt.hd4fans.org",
   "icon": "https://pt.hd4fans.org/favicon.ico",
-  "tags": ["影视", "兽组"],
+  "tags": [
+    "影视",
+    "兽组"
+  ],
   "host": "pt.hd4fans.org",
-  "collaborator": "lilungpo"
+  "collaborator": "lilungpo, tongyifan",
+  "searchEntry": [
+    {
+      "name": "全站",
+      "enabled": true
+    },
+    {
+      "queryString": "cat401=1",
+      "name": "电影",
+      "enabled": false
+    },
+    {
+      "queryString": "cat404=1",
+      "name": "纪录片",
+      "enabled": false
+    },
+    {
+      "queryString": "cat405=1",
+      "name": "动漫",
+      "enabled": false
+    },
+    {
+      "queryString": "cat402=1",
+      "name": "电视剧",
+      "enabled": false
+    },
+    {
+      "queryString": "cat403=1",
+      "name": "综艺",
+      "enabled": false
+    },
+    {
+      "queryString": "cat406=1",
+      "name": "MV",
+      "enabled": false
+    },
+    {
+      "queryString": "cat407=1",
+      "name": "体育",
+      "enabled": false
+    },
+    {
+      "queryString": "cat409=1",
+      "name": "其它",
+      "enabled": false
+    },
+    {
+      "queryString": "cat408=1",
+      "name": "音轨",
+      "enabled": false
+    }
+  ],
+  "categories": [
+    {
+      "entry": "*",
+      "result": "&cat$id$=1",
+      "category": [
+        {
+          "id": 401,
+          "name": "电影"
+        },
+        {
+          "id": 404,
+          "name": "纪录片"
+        },
+        {
+          "id": 405,
+          "name": "动漫"
+        },
+        {
+          "id": 402,
+          "name": "电视剧"
+        },
+        {
+          "id": 403,
+          "name": "综艺"
+        },
+        {
+          "id": 406,
+          "name": "MV"
+        },
+        {
+          "id": 407,
+          "name": "体育"
+        },
+        {
+          "id": 409,
+          "name": "其它"
+        },
+        {
+          "id": 408,
+          "name": "音轨"
+        }
+      ]
+    }
+  ],
+  "torrentTagSelectors": [
+    {
+      "name": "Free",
+      "selector": "img.pro_free, .free_bg, font.free"
+    },
+    {
+      "name": "2xFree",
+      "selector": "img.pro_free2up, font.twoupfree"
+    },
+    {
+      "name": "2xUp",
+      "selector": "img.pro_2up, .twoup_bg, font.twoup"
+    },
+    {
+      "name": "2x50%",
+      "selector": "img.pro_50pctdown2up, .twouphalfdown_bg, font.twouphalfdown"
+    },
+    {
+      "name": "30%",
+      "selector": "img.pro_30pctdown, .thirtypercentdown_bg, font.thirtypercent"
+    },
+    {
+      "name": "50%",
+      "selector": "img.pro_50pctdown, .halfdown_bg, font.halfdown"
+    }
+  ],
+  "searchEntryConfig": {
+    "fieldSelector": {
+      "progress": {
+        "selector": [
+          "div[class='progressarea'] > div"
+        ],
+        "filters": [
+          "query.attr('style').match(/(\\d+(?:\\.\\d+)?)%/)[1]"
+        ]
+      }
+    }
+  }
 }


### PR DESCRIPTION
由于HD4FANS的置顶种使用了twoupfree_bg，因此所有置顶种都会被错误的标记为2xFree，因此在torrentTagSelectors中将此class去除。不过这也引发了设置为高亮显示时2xFree无效的情况，其实最好的解决方法还是联系站点修改class了（笑