### PR TITLE
feat: 新增Concertos

### DIFF
--- a/resource/schemas/Common/torrents.js
+++ b/resource/schemas/Common/torrents.js
@@ -25,13 +25,14 @@
         //  "获取下载链接失败，未能正确定位到链接";
         return this.t("getDownloadURLsFailed");
       }
-
-      let urls = $.map(links, item => {
-        let url = $(item).attr("href");
-        return this.getFullURL(url);
-      });
-
-      return urls;
+      if (typeof(links[0])!="string"){
+        let urls = $.map(links, item => {
+          let url = $(item).attr("href");
+          return this.getFullURL(url);
+        });
+        return urls;
+      }
+      return links
     }
 
     /**

--- a/resource/sites/concertos.live/config.json
+++ b/resource/sites/concertos.live/config.json
@@ -1,0 +1,146 @@
+{
+  "name": "Concertos",
+  "timezoneOffset": "+0000",
+  "description": "Concertos",
+  "url": "https://concertos.live/",
+  "tags": ["MV"],
+  "schema": "Common",
+  "plugins": [{
+    "name": "种子详情页面",
+    "pages": ["/torrent/"],
+    "scripts": ["/schemas/NexusPHP/common.js", "/schemas/Common/details.js"]
+  }, {
+    "name": "种子列表",
+    "pages": ["/torrents"],
+    "scripts": ["/schemas/NexusPHP/common.js", "/schemas/Common/torrents.js"]
+  }],
+  "host": "concertos.live",
+  "searchEntryConfig": {
+    "page": "/torrents?title=$key$&order_by=created_at&direction=desc",
+    "resultType": "html",
+    "resultSelector": "table.table.table--bordered-big.torrents",
+    "fieldIndex": {
+	    "category": 0,
+	    "title": 1,
+	    "link": 1,
+	    "url": 1,
+        "time": 2,
+        "size": 3,
+        "author": 1,
+        "seeders": 4,
+        "leechers": 5,
+        "completed": 6
+	},
+	"fieldSelector": {
+	  "title": {
+		"selector": ["a.torrents__title"],
+        "filters": ["query.text()"]
+	  },
+	  "link": {
+		"selector": ["a.torrents__title"],
+        "filters": ["query.attr('href')"]
+	  },
+	  "url": {
+		"selector": ["a.torrents__title"],
+        "filters": ["query.attr('href')", "query + '/download'"]
+	  },
+	  "time": {
+		"selector": [""],
+        "filters": [""]
+	  }
+	}
+  },
+  "searchEntry": [{
+    "name": "全部",
+    "enabled": true
+  }],
+  "torrentTagSelectors": [{
+    "name": "Free",
+    "selector": "img[src='images/freeleech.png']"
+  }],
+  "selectors": {
+    "userBaseInfo": {
+      "page": "/",
+      "fields": {
+        "name": {
+          "selector": ["div.user-info"],
+          "filters": ["$(query[0].firstChild).text().trim()"]
+        },
+        "id": {
+	      "selector": [".nav > a.nav__link[href*='/user']:first"],
+          "filters": ["query.attr('href').replace('https://concertos.live/user/', '')"]
+        },
+        "isLogged": {
+          "selector": ["div.user-info"],
+          "filters": ["query.length>0"]
+        },
+        "messageCount": {
+          "selector": ["div.info-bar"],
+          "filters": ["query.text().match(/(\\d+)/)", "(query && query.length>=2)?parseInt(query[1]):0"]
+        },
+        "uploaded": {
+          "selector": [".user-info__item > .fa-upload"],
+          "filters": ["query.parent().text().trim().replace(/,/g,'').match(/([\\d.]+ ?[ZEPTGMK]?i?B)/)", "(query && query.length>=2)?(query[1]).sizeToNumber():0"]
+        },
+        "downloaded": {
+          "selector": [".user-info__item > .fa-download"],
+          "filters": ["query.parent().text().trim().replace(/,/g,'').match(/([\\d.]+ ?[ZEPTGMK]?i?B)/)", "(query && query.length>=2)?(query[1]).sizeToNumber():0"]
+        },
+        "ratio": {
+          "selector": [".user-info__item > .fa-percent"],
+          "filters": ["query.parent().text().trim().replace('Ratio: ', '')"]
+        }, 
+        "levelName": {
+          "selector": [".user-info__item > .fa-user"],
+          "filters":  ["query.parent().text().trim().split(' ')[0]"]
+        }
+      }
+    },
+    "userExtendInfo": {
+      "page": "/user/$user.id$",
+      "fields": {
+        "joinTime": {
+          "selector": ["div.profile-block__age"],
+          "filters": ["dateTime(query.text().replace('Member since ', '')).valueOf()"]
+        },
+        "bonus": {
+	      "selector": ["td:contains('BONs') + td"],
+          "filters": ["query.text().trim().replace(' ', '')"]
+          
+        },
+        "seeding": {
+	      "selector": ["td:contains('Total Seeding') + td"],
+          "filters": ["query.text().match(/(\\d+)/)", "(query && query.length>=2)?parseInt(query[1]):0"]
+        },
+        "seedingSize": {
+          "value": -1
+        }
+      }
+    },
+    "common": {
+	  "page": "/torrent/",
+      "fields": {
+        "downloadURL": {
+          "selector": ["a[href*='/download']"],
+          "filters": ["query.attr('href')"]
+        },
+        "size": {
+          "selector": ["td.torrent__meta-title:contains('Size') + td"],
+          "filters": ["query.text().replace(/,/g,'').match(/([\\d.]+ ?[ZEPTGMK]?i?B)/)", "(query && query.length>1)?(query[1]).sizeToNumber():0"]
+        },
+        "sayThanksButton": {
+          "selector": ["a[href*='/thank']"],
+          "filters": ["query"]
+        },
+        "downloadURLs": {
+		"selector": ["a.torrents__title"],
+        "filters": ["query.toArray()", "query.map((item)=>{return item.href+'/download'})"]
+        },
+        "confirmSize": {
+          "selector": ["table.table.table--bordered-big.torrents"],
+          "filters": ["query.find('td.torrents__size')"]
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
由于Concertos本身种子页面不提供下载，因此由脚本生成，更改了模板架构已便于直接获取连接