### PR TITLE
Fix: 适配LeagueHD 改版后种子详情页面ptpp工作问题

### DIFF
--- a/resource/sites/leaguehd.com/config.json
+++ b/resource/sites/leaguehd.com/config.json
@@ -26,6 +26,22 @@
         "/schemas/NexusPHP/common.js",
         "/schemas/NexusPHP/torrents.js"
       ]
+    },
+    {
+      "name": "种子详情页面",
+      "pages": [
+        "/details_movie.php",
+        "/details_tv.php",
+        "/details_music.php",
+        "/details_animate.php",
+        "/details_mv.php",
+        "/details_doc.php",
+        "/details_other.php"
+      ],
+      "scripts": [
+        "/schemas/NexusPHP/common.js",
+        "/schemas/NexusPHP/details.js"
+      ]
     }
   ],
   "collaborator": "enigmaz",
@@ -105,7 +121,7 @@
             "td.rowfollow:contains('总做种数')"
           ],
           "filters": [
-            "query.text().replace(/,/g,'').match(/(?:总做种数|seedingSize).+?([\\d.]+)/)",
+            "query.text().replace(/,/g,'').match(/(?:总做种数|seeding).+?([\\d.]+)/)",
             "(query && query.length>=2)?query[1]:0"
           ]
         },


### PR DESCRIPTION

## Fix: 柠檬种子详情页面ptpp不工作问题修复

## type 说明

- fix: 修补 bug

## 内容说明

柠檬底层大改后，已适配完成搜索，批量发送，保种数据错误。
经用户测试，种子详情页工作不正常，分析为原种子详情页面为 `url/details.php` ，改版后为`url/details_大分类.php`
修改适配后，问题已解决。
望大佬merge 修改。感谢感谢