### PR TITLE
Fix: LeagueHD 修复豆瓣，imdb 搜索失效，最新种子页面无侧边栏

### DIFF
--- a/resource/sites/leaguehd.com/config.json
+++ b/resource/sites/leaguehd.com/config.json
@@ -14,6 +14,7 @@
     {
       "name": "种子列表",
       "pages": [
+        "/torrents_new.php",
         "/torrents_movie.php",
         "/torrents_tv.php",
         "/torrents_music.php",
@@ -44,7 +45,7 @@
       ]
     }
   ],
-  "collaborator": "enigmaz",
+  "collaborator": "enigmaz, timyuan",
   "searchEntryConfig": {
     "page": "/torrents_movie.php",
     "queryString": "search=$key$",
@@ -53,6 +54,11 @@
       {
         "name": "标题",
         "appendQueryString": "&search_area=name"
+      },
+      {
+        "name": "IMDB",
+        "keyAutoMatch": "^(tt\\d+)$",
+        "appendQueryString": "&search_area=imdb"
       }
     ],
     "fieldSelector": {
@@ -75,6 +81,11 @@
     }
   },
   "searchEntry": [
+    {
+      "entry": "/torrents.php?search=$key$",
+      "name": "全站",
+      "enabled": false
+    },
     {
       "entry": "/torrents_movie.php?search=$key$",
       "name": "电影",


### PR DESCRIPTION
## Fix: LeagueHD 修复豆瓣，imdb 搜索失效，最新种子页面无侧边栏
### type 说明
- fix: 修补 bug
### 内容说明
本次更新为用户使用中反馈新问题修复。
1. 修复使用豆瓣api 返回数据无法搜索问题
2. 修复最新种子页面无侧边栏
经chrome firefox edge 测试功能正常。
望大佬merge 修改。感谢感谢