### PR TITLE
Fix: 修复猫站无法获取保种信息

### DIFF
--- a/resource/sites/pterclub.com/config.json
+++ b/resource/sites/pterclub.com/config.json
@@ -60,11 +60,11 @@
       }
     },
     "userSeedingTorrents": {
-      "page": "/getusertorrentlistajax.php?userid=$user.id$&type=seeding",
+      "page": "/getusertorrentlist.php?userid=$user.id$&type=seeding",
       "fields": {
         "seeding": {
           "selector": ["tr:not(:eq(0))"],
-          "filters": ["query.find('td.rowfollow:eq(2)').length"]
+          "filters": ["query.find('td.rowfollow:eq(1)').length"]
         },
         "seedingSize": {
           "selector": ["tr:not(:eq(0))"],


### PR DESCRIPTION
## Fix: 修复猫站无法获取保种信息问题

## type 说明

- fix: 修补 bug

## 内容说明

因猫站改版，保种信息获取方式已变更。重新适配后，经测试，已可正常显示保种信息。
望大佬merge 修改。感谢感谢