### PR TITLE
feat: support sites with hash/downhash instead of passkey

### DIFF
--- a/resource/schemas/NexusPHP/common.js
+++ b/resource/schemas/NexusPHP/common.js
@@ -534,7 +534,7 @@
            * 两个事件必需执行一个，可以传递一个参数
            */
           click: (success, error) => {
-            // getDownloadURL 方法有继承者提供
+            // getDownloadURL 方法由继承者提供
             if (!this.getDownloadURL) {
               // "getDownloadURL 方法未定义"
               error(this.t("getDownloadURLisUndefined"));

--- a/resource/schemas/NexusPHP/details.js
+++ b/resource/schemas/NexusPHP/details.js
@@ -14,20 +14,38 @@
     }
 
     /**
+     * 通过尝试分析 href 获取真正下载链接
+     */
+
+    _getDownloadUrlByPossibleHrefs() {
+      const possibleHrefs = [
+        // pthome
+        "a[href*='downhash'][href*='https']",
+        // hdchina
+        "a[href*='hash'][href*='https']",
+        // misc
+        "a[href*='passkey'][href*='https']",
+        "a[href*='passkey']"
+      ];
+
+      for (const href of possibleHrefs) {
+        const query = $(href);
+        if (query.length) {
+          return query.attr("href");
+        }
+      }
+      return null;
+    }
+
+
+    /**
      * 获取下载链接
      */
     getDownloadURL() {
       let url = PTService.getFieldValue("downloadURL");
       if (!url) {
-        let query = $("a[href*='passkey'][href*='https']");
-        if (query.length > 0) {
-          url = query.attr("href");
-        } else {
-          query = $("a[href*='passkey']");
-          if (query.length > 0) {
-            url = query.attr("href");
-          }
-        }
+
+        url = this._getDownloadUrlByPossibleHrefs();
 
         if (!url) {
           url =


### PR DESCRIPTION
某些站点的种子文件下载地址并不使用 `passkey` 作为鉴权，而是使用一次性哈希，如 pthome 使用 `downhash`，HDC 使用 `hash`