### PR TITLE
新增iTS部分支持及BTN bug修复

### DIFF
--- a/resource/sites/broadcasthe.net/config.json
+++ b/resource/sites/broadcasthe.net/config.json
@@ -1,6 +1,6 @@
 {
   "name": "BTN",
-  "timezoneOffset": "+0000",
+  "timezoneOffset": "+0800",
   "description": "著名剧集站点，又被戏称为鼻涕妞",
   "url": "https://broadcasthe.net/",
   "icon": "https://broadcasthe.net/favicon.ico",

--- a/resource/sites/broadcasthe.net/getSearchResult.js
+++ b/resource/sites/broadcasthe.net/getSearchResult.js
@@ -160,16 +160,17 @@
 
     getTime(timeStr) {
       let timeRegex = timeStr.match(
-        /((\d+).+?(minute|hour|day|month|year)s?.+?and.+?)?(\d+).+?(minute|hour|day|month|year)s?/
+        /((\d+).+?(minute|hour|day|week|month|year)s?.*?(\,|and))?.*?(\d+).+?(minute|hour|day|week|month|year)s?/
       );
       let milliseconds = 0;
       if (timeRegex) {
         if (timeRegex[1] == undefined) {
-          milliseconds = this.getMilliseconds(timeRegex[4], timeRegex[5]);
+          milliseconds = this.getMilliseconds(timeRegex[5], timeRegex[6]);
         } else {
-          milliseconds = this.getMilliseconds(timeRegex[2], timeRegex[3]) + this.getMilliseconds(timeRegex[4], timeRegex[5]);
+          milliseconds = this.getMilliseconds(timeRegex[2], timeRegex[3]) + this.getMilliseconds(timeRegex[5], timeRegex[6]);
         }
       }
+      console.log(timeRegex);
       let timeStamp = Date.now() - milliseconds;
       let date = new Date(timeStamp);
       return date.toISOString();
@@ -183,7 +184,9 @@
       if(unit == "hour") {return milliseconds;}
       milliseconds = milliseconds*24;
       if(unit == "day") {return milliseconds;}
-      milliseconds = milliseconds*30;
+      milliseconds = milliseconds*7;
+      if(unit == "week") {return milliseconds;}
+      milliseconds = milliseconds*30/7;
       if(unit == "month") {return milliseconds;}
       milliseconds = milliseconds*12;
       return milliseconds;

--- a/resource/sites/nebulance.io/config.json
+++ b/resource/sites/nebulance.io/config.json
@@ -72,7 +72,7 @@
         },
         "bonus": {
           "selector": "ul#userinfo_major > li > a:contains('Cubits:')",
-          "filters": ["query.text().replace(/,|\\n|\\s+/g,'').match(/Cubits:.+?([\\d.]+)/)", "(query && query.length>=2)?query[1]:0"]
+          "filters": ["query.text().replace(/,/g,'').match(/Cubits:.+?([\\d.]+)/)", "(query && query.length>=2)?query[1]:0"]
         },
         "joinTime": {
           "selector": ["ul.stats.nobullet > li:contains('Joined:') > span"],

--- a/resource/sites/shadowthein.net/browse.js
+++ b/resource/sites/shadowthein.net/browse.js
@@ -1,0 +1,70 @@
+(function($) {
+  console.log("this is browse.js");
+  class App extends window.NexusPHPCommon {
+    init() {
+      this.initButtons();
+      this.initFreeSpaceButton();
+      // 设置当前页面
+      PTService.pageApp = this;
+    }
+
+    /**
+     * 初始化按钮列表
+     */
+    initButtons() {
+      this.initListButtons();
+    }
+
+    /**
+     * 获取下载链接
+     */
+    getDownloadURLs() {
+      let links = $(
+        "table#torrenttable:last a[href*='download.php']"
+      ).toArray();
+      let siteURL = PTService.site.url;
+      if (siteURL.substr(-1) != "/") {
+        siteURL += "/";
+      }
+
+      if (links.length == 0) {
+        // "获取下载链接失败，未能正确定位到链接";
+        return this.t("getDownloadURLsFailed");
+      }
+
+      let urls = $.map(links, item => {
+        let link = $(item).attr("href");
+        if (link && link.substr(0, 4) != "http") {
+          link = siteURL + link;
+        }
+        return link;
+      });
+
+      return urls;
+    }
+
+    /**
+     * 确认大小是否超限
+     */
+    confirmWhenExceedSize() {
+      return this.confirmSize(
+        $("table#browse:last").find(
+          "td:contains('MB'),td:contains('GB'),td:contains('TB')"
+        )
+      );
+    }
+
+    /**
+     * 获取有效的拖放地址
+     * @param {*} url
+     */
+    getDroperURL(url) {
+      if (url.indexOf("down.php") === -1) {
+        return "";
+      }
+
+      return url;
+    }
+  }
+  new App().init();
+})(jQuery);

--- a/resource/sites/shadowthein.net/config.json
+++ b/resource/sites/shadowthein.net/config.json
@@ -58,17 +58,9 @@
     "userExtendInfo": {
       "page": "/userdetails.php?id=$user.id$",
       "fields": {
-        "uploaded": {
-          "selector": ["to do"],
-          "filters": ["to do"]
-        },
-        "downloaded": {
-          "selector": ["to do"],
-          "filters": ["to do"]
-        },
-        "ratio": {
-          "selector": ["to do"],
-          "filters": ["to do"]
+        "seeding": {
+          "selector": ["div#seeds_div"],
+          "filters": ["query.text().match(/([\\d.]+).*?-/)", "(query && query.length>=2)?query[1]:0"]
         },
         "levelName": {
           "selector": ["td.row2:contains('Tracker'):contains('Class') + td"]
@@ -84,9 +76,17 @@
       }
     },
     "userSeedingTorrents": {
-      "page": "/current.php?id=$user.id$",
+      "page": "/",
       "fields": {
-        "seeding": {
+        "uploaded": {
+          "selector": ["to do"],
+          "filters": ["to do"]
+        },
+        "downloaded": {
+          "selector": ["to do"],
+          "filters": ["to do"]
+        },
+        "ratio": {
           "selector": ["to do"],
           "filters": ["to do"]
         },

--- a/resource/sites/shadowthein.net/config.json
+++ b/resource/sites/shadowthein.net/config.json
@@ -1,0 +1,101 @@
+{
+  "name": "inTheShadow",
+  "timezoneOffset": "+0000",
+  "description": "iTS",
+  "url": "https://shadowthein.net/",
+  "icon": "https://shadowthein.net/favicon.ico",
+  "tags": ["影视", "音乐", "文学"],
+  "schema": "iTS",
+  "host": "shadowthein.net",
+  "collaborator": "luckiestone",
+  "plugins": [{
+    "name": "种子详情页面",
+    "pages": ["/details.php"],
+    "scripts": ["/schemas/NexusPHP/common.js", "details.js"]
+  }, {
+    "name": "种子列表",
+    "pages": ["/browse.php"],
+    "scripts": ["/schemas/NexusPHP/common.js", "browse.js"]
+  }],
+  "searchEntryConfig": {
+    "page": "/browse.php",
+    "queryString": "search=$key$&incldead=1",
+    "resultType": "html",
+    "parseScriptFile": "getSearchResult.js",
+    "resultSelector": "table[id='torrenttable']:last > tbody > tr",
+    "area": [{
+      "name": "IMDB",
+      "keyAutoMatch": "^(tt\\d+)$",
+      "queryString": "incldead=1&search=$key$&search_in=all"
+    }]
+  },
+  "searchEntry": [{
+    "name": "All",
+    "enabled": true
+  }],
+  "selectors": {
+    "userBaseInfo": {
+      "page": "/",
+      "fields": {
+        "id": {
+          "selector": "a[href*='userdetails.php']:first",
+          "attribute": "href",
+          "filters": ["query ? query.getQueryString('id'):''"]
+        },
+        "name": {
+          "selector": "a[href*='userdetails.php']:first"
+        },
+        "isLogged": {
+          "selector": ["a[href*='logout.php']"],
+          "filters": ["query.length>0"]
+        },
+        "messageCount": {
+          "selector": ["td[bgcolor*='red'] a[href*='message.php']"],
+          "filters": ["query.text().match(/(\\d+)/)", "(query && query.length>=2)?parseInt(query[1]):0"]
+        }
+      }
+    },
+    "userExtendInfo": {
+      "page": "/userdetails.php?id=$user.id$",
+      "fields": {
+        "uploaded": {
+          "selector": ["to do"],
+          "filters": ["to do"]
+        },
+        "downloaded": {
+          "selector": ["to do"],
+          "filters": ["to do"]
+        },
+        "ratio": {
+          "selector": ["to do"],
+          "filters": ["to do"]
+        },
+        "levelName": {
+          "selector": ["td.row2:contains('Tracker'):contains('Class') + td"]
+        },
+        "joinTime": {
+          "selector": ["td.row2:contains('Join'):contains('Date') + td"],
+          "filters": ["query.text().split(' (')[0]", "dateTime(query).isValid()?dateTime(query).valueOf():query"]
+        },
+        "bonus": {
+          "selector": "td.row2:contains('Karma') + td",
+          "filters": ["query.text().replace(/,|\\n|\\s+/g,'')"]
+        }
+      }
+    },
+    "userSeedingTorrents": {
+      "page": "/current.php?id=$user.id$",
+      "fields": {
+        "seeding": {
+          "selector": ["to do"],
+          "filters": ["to do"]
+        },
+        "seedingSize": {
+          "selector": ["to do"],
+          "filters": ["to do"]
+        }
+      }
+    }
+
+  }
+}

--- a/resource/sites/shadowthein.net/details.js
+++ b/resource/sites/shadowthein.net/details.js
@@ -1,0 +1,58 @@
+(function($, window) {
+  console.log("this is details.js");
+  class App extends window.NexusPHPCommon {
+    init() {
+      this.initButtons();
+      // 设置当前页面
+      PTService.pageApp = this;
+    }
+    /**
+     * 初始化按钮列表
+     */
+    initButtons() {
+      this.showTorrentSize();
+      this.initDetailButtons();
+    }
+
+    /**
+     * 获取下载链接
+     */
+    getDownloadURL() {
+      let query = $("a.index[href*='download.php']");
+      let url = "";
+      if (query.length > 0) {
+        url = query.attr("href");
+      }
+
+      if (!url) {
+        return "";
+      }
+
+      return `${location.origin}${url}`;
+    }
+
+    showTorrentSize() {
+      let query = $("td.row2:contains('Size') + td");
+      let size = "";
+      if (query.length > 0) {
+        size = query.text().match(/^[^\(]+/);
+        // attachment
+        PTService.addButton({
+          title: "当前种子大小",
+          icon: "attachment",
+          label: size
+        });
+      }
+    }
+
+    /**
+     * 获取当前种子标题
+     */
+    getTitle() {
+      return $("table.main h1:first")
+        .text()
+        .trim();
+    }
+  }
+  new App().init();
+})(jQuery, window);

--- a/resource/sites/shadowthein.net/getSearchResult.js
+++ b/resource/sites/shadowthein.net/getSearchResult.js
@@ -1,0 +1,170 @@
+(function(options) {
+  class Parser {
+    constructor() {
+      this.haveData = false;
+      if (/takelogin\.php/.test(options.responseText)) {
+        options.status = ESearchResultParseStatus.needLogin;
+        return;
+      }
+
+      options.isLogged = true;
+
+      if (
+        /没有种子|No [Tt]orrents?|Your search did not match anything|用准确的关键字重试/.test(
+          options.responseText
+        )
+      ) {
+        options.status = ESearchResultParseStatus.noTorrents;
+        return;
+      }
+
+      this.haveData = true;
+    }
+
+    /**
+     * 获取搜索结果
+     */
+    getResult() {
+      if (!this.haveData) {
+        return [];
+      }
+
+      let results = [];
+      let site = options.site;
+      // 获取种子列表行
+      let rows = options.page.find(
+        options.resultSelector || "table[id='torrenttable']:last > tbody > tr"
+      );
+      // 用于定位每个字段所列的位置
+      let fieldIndex = {
+        //title
+        title: 1,
+        //downloadlink
+        downloadlink: 3,
+        // 时间
+        time: 6,
+        // 大小
+        size: 7,
+        // 上传人数
+        seeders: 9,
+        // 下载人数
+        leechers: 10,
+        // 完成人数
+        completed: 8,
+        // 评论人数
+        comments: 5,
+        // 发布人
+        author: 11,
+        category: 0
+      };
+
+      if (site.url.substr(-1) == "/") {
+        site.url = site.url.substr(0, site.url.length - 1);
+      }
+
+      // 遍历数据行
+      for (let index = 1; index < rows.length; index++) {
+        const row = rows.eq(index);
+        let cells = row.find(">td");
+        let title = cells.eq(fieldIndex.title).find("a[href*='details.php?id=']").first();
+        if (title.length == 0) {
+          continue;
+        }
+        let titleStrings = title.text();
+        let link = title.attr("href");
+        if (link && link.substr(0, 4) !== "http") {
+          link = `${site.url}/${link}`;
+        }
+        let url = "";
+        url = cells.eq(fieldIndex.downloadlink).find("a[href*='/download.php']").first().attr("href");
+          if (url && url.substr(0, 4) !== "http") {
+            url = `${site.url}/${url}`;
+          }
+
+        if (!url) {
+          continue;
+        }
+        let time = cells.eq(fieldIndex.time).text();
+        let data = {
+          title: titleStrings,
+          link: link,
+          url: url,
+          size: cells.eq(fieldIndex.size).text() || 0,
+          time: time,
+          author: cells.eq(fieldIndex.author).text() || "",
+          seeders:
+            cells
+              .eq(fieldIndex.seeders)
+              .text(),
+          leechers:
+            cells
+              .eq(fieldIndex.leechers)
+              .text(),
+          completed: cells.eq(fieldIndex.completed).text(),
+          comments: cells.eq(fieldIndex.comments).find("a[href*='#startcomments']").text() || 0,
+          site: site,
+          entryName: options.entry.name,
+          category: this.getCategory(cells.eq(fieldIndex.category)),
+          tags: this.getTags(row, options.torrentTagSelectors)
+        };
+        results.push(data);
+      }
+
+      if (results.length == 0) {
+        options.status = ESearchResultParseStatus.noTorrents;
+      }
+
+      return results;
+    }
+
+    /**
+     * 获取分类
+     * @param {*} cell 当前列
+     */
+    getCategory(cell) {
+      let result = {
+        name: "",
+        link: ""
+      };
+      let link = cell.find("a:first");
+      let img = link.find("img:first");
+
+      result.link = link.attr("href");
+      if (result.link.substr(0, 4) !== "http") {
+        result.link = options.site.url + result.link;
+      }
+
+      result.name = img.attr("alt");
+      return result;
+    }
+
+    /**
+     * 获取标签
+     * @param {*} row
+     * @param {*} selectors
+     * @return array
+     */
+    getTags(row, selectors) {
+      let tags = [];
+      if (selectors && selectors.length > 0) {
+        // 使用 some 避免错误的背景类名返回多个标签
+        selectors.some(item => {
+          if (item.selector) {
+            let result = row.find(item.selector);
+            if (result.length) {
+              tags.push({
+                name: item.name,
+                color: item.color
+              });
+              return true;
+            }
+          }
+        });
+      }
+      return tags;
+    }
+  }
+  let parser = new Parser(options);
+  options.results = parser.getResult();
+  console.log(options.results);
+})(options);


### PR DESCRIPTION
- feat: 新增iTS支持，除个人数据部分未获取外，搜索、批量下载、消息提醒等已完成。
  - 说明：
    - 待完善：用户数据中的`uploaded`  `downloaded` `ratio`  `seedingSize`的获取
    - 完善思路：由于站点为ratioless，且目前不直接展示上述数据，处于强迫症需求，上述数据可通过额外计算获得。
userdetails页面script包含ttables()函数，函数中可获取到uploads, downloads, seeds和leech四个种子页面地址。
downloads和leech两个页面可计算出总下载量。
结合站点给出的Total traffic数据可计算出`uploaded`  `downloaded` `ratio`三个数据，`seedingSize`通过seeds页面获取。

- feat: 修复BTN搜索结果中发布时间错误的bug
  - 修复BTN发布时间中包含周数不能识别的bug
  - 修复BTN发布时间中含有`,`识别错误的bug
  - 修改时区为+8

**期待有能力的可以完善上述iTS部分数据的获取**，如无强迫症，可merge。

