### PR TITLE
更新Github Action

### DIFF
--- a/.github/workflows/dev_build.yml
+++ b/.github/workflows/dev_build.yml
@@ -17,8 +17,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@master
-        with:
-          ref: dev
 
       - name: Setup Node
         uses: actions/setup-node@v2


### PR DESCRIPTION
- 之前: 所以PR只会checkout dev分支
- 现在: 所有PR会checkout PR自己的分支, 这样普通用户就能直接在PR里面下载测试