### PR TITLE
Fix: 修复柠檬搜索，切换到全站搜索

### DIFF
--- a/resource/sites/lemonhd.org/config.json
+++ b/resource/sites/lemonhd.org/config.json
@@ -85,7 +85,7 @@
   },
   "searchEntry": [
     {
-      "entry": "/torrents.php?search_area=0&search=$key$",
+      "entry": "/torrents.php?search_area=name&search=$key$",
       "name": "全站",
       "enabled": true
     },


### PR DESCRIPTION
## Fix: 切换搜索范围
### type 说明
- fix: 防止分类搜索变动，导致需要经常修改
### 内容说明
其实两个月前已切换为全站搜索，今天全站搜索又有变动导致无法搜索无法返回结果。已与柠檬开发确认比次变动已固定，长时间不会变动。
经chrome firefox edge 测试功能正常。
望大佬merge 修改。感谢感谢