### PR TITLE
fix: 取消图表间空隙

### DIFF
--- a/src/options/views/statisticCharts/SiteBase.vue
+++ b/src/options/views/statisticCharts/SiteBase.vue
@@ -51,10 +51,10 @@
       <v-progress-circular indeterminate :width="3" size="30" color="green" v-if="shareing" class="by_pass_canvas"></v-progress-circular>
     </v-layout>
 
-    <div ref="charts">
+    <div ref="charts" class="charts">
       <highcharts :options="chartBarData" />
-      <highcharts :options="chartBaseData" />
-      <highcharts :options="chartExtData" />
+      <highcharts :options="chartBaseData" class="mt-4" />
+      <highcharts :options="chartExtData" class="mt-4" />
 
       <v-card-actions>
         <v-spacer></v-spacer>
@@ -893,16 +893,16 @@ export default Vue.extend({
       let div = this.$refs.charts as HTMLDivElement;
       this.shareing = true;
       this.shareTime = new Date();
-      domtoimage.toBlob(div, {
+      domtoimage.toJpeg(div, {
         filter: (node) => {
           if (node.nodeType === 1) {
             return !(node as Element).classList.contains('by_pass_canvas')
           }
           return true
         }
-      }).then((blob: any) => {
-        if (blob) {
-          FileSaver.saveAs(blob, "PT-Plugin-Plus-UserData.png");
+      }).then((dataUrl: any) => {
+        if (dataUrl) {
+          FileSaver.saveAs(dataUrl, "PT-Plugin-Plus-UserData.jpg");
         }
         this.shareing = false;
       });
@@ -963,6 +963,10 @@ export default Vue.extend({
 .container {
   width: 900px;
   padding: 0;
+
+  .charts {
+    background-color: white;
+  }
 
   .chart {
     min-width: 320px;

--- a/src/options/views/statisticCharts/SiteBase.vue
+++ b/src/options/views/statisticCharts/SiteBase.vue
@@ -54,7 +54,7 @@
     <div ref="charts">
       <highcharts :options="chartBarData" />
       <highcharts :options="chartBaseData" />
-      <highcharts :options="chartExtData" class="mt-4" />
+      <highcharts :options="chartExtData" />
 
       <v-card-actions>
         <v-spacer></v-spacer>


### PR DESCRIPTION
图标统计分享是生成png图片, 中间的空隙就是透明背景, 当把png发送到黑色背景的地方时候, 中间的缝隙也变成了黑色, 特别难看。