### PR TITLE
feat: add site support for JPTV.club

### DIFF
--- a/resource/sites/jptv.club/config.json
+++ b/resource/sites/jptv.club/config.json
@@ -1,0 +1,14 @@
+{
+    "name": "JPTV",
+    "timezoneOffset": "+0800",
+    "schema": "UNIT3D",
+    "url": "https://jptv.club/",
+    "description": "JPTV",
+    "tags": [
+        "影视",
+        "剧集",
+        "动漫"
+    ],
+    "host": "jptv.club",
+    "collaborator": "MewX"
+}


### PR DESCRIPTION
Adding JPTV support.

This site has been created for 1+ year and has 20k+ torrents at the moment.