### PR TITLE
feat: add site support for SugoiMusic

### DIFF
--- a/resource/sites/sugoimusic.me/config.json
+++ b/resource/sites/sugoimusic.me/config.json
@@ -1,0 +1,45 @@
+{
+  "name": "SugoiMusic",
+  "timezoneOffset": "+0800",
+  "description": "music",
+  "url": "https://sugoimusic.me/",
+  "icon": "https://sugoimusic.me/favicon.ico",
+  "tags": [
+    "音乐"
+  ],
+  "schema": "GazelleJSONAPI",
+  "host": "sugoimusic.me",
+  "collaborator": [
+    "MewX"
+  ],
+  "searchEntryConfig": {
+    "skipIMDbId": true
+  },
+  "selectors": {
+    "userSeedingTorrents": {
+      "page": "/user.php?id=$user.id$",
+      "merge": true,
+      "fields": {
+        "seedingSize": {
+          "selector": [
+            "li:contains('Total Seeding:') > span"
+          ],
+          "filters": [
+            "query.text().trim().sizeToNumber()"
+          ]
+        },
+        "bonus": {
+          "selector": [
+            "#bonus_points > span"
+          ],
+          "filters": [
+            "query.text().trim().replace(',', '')"
+          ]
+        }
+      }
+    }
+  },
+  "supportedFeatures": {
+    "imdbSearch": false
+  }
+}


### PR DESCRIPTION
Adding site support for SugoiMusic.

SugoiMusic is a music tracker built by jpop staff. It has 3.5k users and 102k torrents.

The commit has been tested locally:

![image](https://user-images.githubusercontent.com/5752560/120915704-a3ef1880-c6e8-11eb-9b28-a5fc4cf05b0d.png)


Note:
- the bonus system in this tracker is called "Sugoi"
- the seeding size can only be fetched in user.php