### PR TITLE
fix: 更改mt的网址

### DIFF
--- a/resource/sites/pt.m-team.cc/config.json
+++ b/resource/sites/pt.m-team.cc/config.json
@@ -2,13 +2,13 @@
   "name": "M-Team",
   "timezoneOffset": "+0800",
   "description": "M-Team",
-  "url": "https://pt.m-team.cc/",
-  "icon": "https://pt.m-team.cc/favicon.ico",
+  "url": "https://kp.m-team.cc/",
+  "icon": "https://kp.m-team.cc/favicon.ico",
   "tags": ["影视", "综合"],
   "schema": "NexusPHP",
-  "host": "pt.m-team.cc",
+  "host": "kp.m-team.cc",
   "formerHosts": [
-    "tp.m-team.cc"
+    "kp.m-team.cc"
   ],
   "plugins": [{
     "name": "种子列表",


### PR DESCRIPTION
用原来的网址获取不到网站数据
把网址改成https://kp.m-team.cc/

