### PR TITLE
feat. add site support for GPW (GreatPosterWall)

### DIFF
--- a/resource/sites/greatposterwall.com/config.json
+++ b/resource/sites/greatposterwall.com/config.json
@@ -1,0 +1,40 @@
+{
+  "name": "GPW",
+  "timezoneOffset": "+0800",
+  "description": "movie",
+  "url": "https://greatposterwall.com/",
+  "icon": "https://greatposterwall.com/favicon.ico",
+  "tags": [
+    "电影"
+  ],
+  "schema": "GazelleJSONAPI",
+  "host": "greatposterwall.com",
+  "collaborator": [
+    "MewX"
+  ],
+  "selectors": {
+    "userSeedingTorrents": {
+      "page": "/bonus.php?action=bprates",
+      "fields": {
+        "seedingSize": {
+          "selector": [
+            "table#bprates_overview > tbody > tr > td:eq(1)"
+          ],
+          "filters": [
+            "query.text().replace(/,/g,'').match(/([\\d.]+ ?[ZEPTGMK]?i?B)/)",
+            "(query && query.length>=2)?(query[1]).sizeToNumber():0"
+          ]
+        },
+        "bonus": {
+          "selector": [
+            "div#content > div.header > h3"
+          ],
+          "filters": [
+            "query.text().replace(/,/g,'').match(/.+?([\\d.]+)/)",
+            "(query && query.length>=2)?query[1]:0"
+          ]
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
GPW is a movie tracker created by DIC team. The site just started internal registrations this month but it already had ~3k torrents.

The commit has been tested locally on Edge:

## User info
![image](https://user-images.githubusercontent.com/5752560/122658773-8031d500-d1b4-11eb-9e4b-876d657272ac.png)

## IMDB Search
![image](https://user-images.githubusercontent.com/5752560/122658768-6abcab00-d1b4-11eb-91d3-43ed10102b9e.png)
