### PR TITLE
feat: 工具栏图标显示未登入站点数

### DIFF
--- a/src/background/config.ts
+++ b/src/background/config.ts
@@ -649,22 +649,18 @@ class Config {
    * @param api
    */
   public getContentFromApi(api: string): Promise<any> {
-    PPF.updateBadge(++this.requestCount);
     return new Promise<any>((resolve?: any, reject?: any) => {
       let content = APP.cache.get(api);
       if (content) {
         resolve(content);
-        PPF.updateBadge(--this.requestCount);
         return;
       }
       $.getJSON(api)
         .done(result => {
           APP.cache.set(api, result);
-          PPF.updateBadge(--this.requestCount);
           resolve(result);
         })
         .fail(result => {
-          PPF.updateBadge(--this.requestCount);
           reject && reject(result);
         });
     });

--- a/src/background/service.ts
+++ b/src/background/service.ts
@@ -359,6 +359,7 @@ export default class PTPlugin {
     this.options.sites.forEach((site: Site) => {
       site.user = this.userData.get(site.host as string);
     });
+    this.updateBadgeForUserData();
   }
 
   /**
@@ -669,5 +670,18 @@ export default class PTPlugin {
    */
   public requestPermissions(permissions: string[]): Promise<any> {
     return PPF.requestPermissions(permissions);
+  }
+
+   public updateBadgeForUserData() {
+    let count = 0
+    for (const site of this.options.sites) {
+      if (!site.allowGetUserInfo || site.offline) {
+        continue
+      }
+      if (site.user && site.user.lastUpdateStatus && site.user.lastUpdateStatus !== EUserDataRequestStatus.success) {
+        count++
+      }
+    }
+    PPF.updateBadge(count);
   }
 }

--- a/src/background/user.ts
+++ b/src/background/user.ts
@@ -294,8 +294,6 @@ export class User {
         return;
       }
 
-      PPF.updateBadge(++this.requestQueueCount);
-
       let request = $.ajax({
         url,
         method: rule.requestMethod || ERequestMethod.GET,
@@ -306,7 +304,6 @@ export class User {
       })
         .done(result => {
           this.removeQueue(host, url);
-          PPF.updateBadge(--this.requestQueueCount);
           let content: any;
           try {
             if (rule.dataType !== ERequestResultType.JSON) {
@@ -335,7 +332,6 @@ export class User {
         })
         .fail((jqXHR, textStatus, errorThrown) => {
           this.removeQueue(host, url);
-          PPF.updateBadge(--this.requestQueueCount);
           let msg = this.service.i18n.t("service.searcher.siteNetworkFailed", {
             site,
             msg: `${jqXHR.status} ${errorThrown}, ${textStatus}`

--- a/src/service/public.ts
+++ b/src/service/public.ts
@@ -55,13 +55,11 @@ class HelpFunctions {
     try {
       if (count == 0) {
         chrome.browserAction.setBadgeText({ text: "" });
-        chrome.browserAction.enable();
       } else {
         chrome.browserAction.setBadgeText({ text: count.toString() });
         chrome.browserAction.setBadgeBackgroundColor({
-          color: "#aabbcc"
+          color: "#f44336"
         });
-        chrome.browserAction.disable();
       }
     } catch (error) {
       console.log(error);


### PR DESCRIPTION
配合自动刷新用户数据就是神器,  和 #842 一起食用味道更佳。 之前的Badge用于显示requests个数, 相比之下这个应该更加实用. 

<img width="46" alt="Screen Shot 2021-07-25 at 1 14 48 PM" src="https://user-images.githubusercontent.com/2525544/126892467-7457661c-944b-4101-9164-3f6ba69bffb2.png">