### PR TITLE
fix: BHD消息提醒不包括bets

### DIFF
--- a/resource/sites/beyond-hd.me/config.json
+++ b/resource/sites/beyond-hd.me/config.json
@@ -87,7 +87,7 @@
           "filters": ["query.parent().text().trim()"]
         },
         "messageCount": {
-          "selector": [".notify"],
+          "selector": [".beta-alert[href$='/mail'] .notify"],
           "filters": ["query[0]?11:0"]
         }
       }


### PR DESCRIPTION
- 之前: 所有消息都会提醒, 包括Bets, 很烦
- 现在: 只有Private Messages会提醒