### PR TITLE
fix: BarChart负值显示

### DIFF
--- a/src/options/views/statisticCharts/SiteBase.vue
+++ b/src/options/views/statisticCharts/SiteBase.vue
@@ -835,25 +835,27 @@ export default Vue.extend({
         tooltip: {
           useHTML: true,
           formatter: function(): any {
-            const { x, total, color, series: { name: siteName } }: any = this
+            const { x, y, total, color, series: { name: siteName } }: any = this
             let sites = []
             for (const site of series) {
               const siteY = (site.data.find(([a]: any[]) => a === x) || [0, 0])[1]
-              if (siteY === 0) {
-                continue
+              if (
+                (y < 0 && siteY < 0) ||
+                (y > 0 && siteY > 0)
+               ) {
+                const percentage = Math.ceil(siteY / total * 100)
+                sites.push({
+                  name: site.name,
+                  value: siteY,
+                  valueDisplay: filters.formatSizeWithNegative(siteY),
+                  percentageDisplay: `${percentage}%`,
+                  isActive: site.name === siteName,
+                })
               }
-              const percentage = Math.ceil(siteY / total * 100)
-              sites.push({
-                name: site.name,
-                value: siteY,
-                valueDisplay: filters.formatSize(siteY),
-                percentageDisplay: `${percentage}%`,
-                isActive: site.name === siteName,
-              })
             }
             sites.sort((a,b) => b.value-a.value)
             const date = dayjs(x).format("YYYY-MM-DD")
-            const totalDisplay = filters.formatSize(total)
+            const totalDisplay = filters.formatSizeWithNegative(total)
             const totalText = $t('statistic.total').toString()
 
             const createTr = ({ name, valueDisplay, percentageDisplay, isActive }: any) => {

--- a/src/service/filters.ts
+++ b/src/service/filters.ts
@@ -1,6 +1,7 @@
 interface IFilter {
   formatNumber: (source: number, format?: string) => string;
   formatSize: (bytes: any, zeroToEmpty?: boolean, type?: string) => string;
+  formatSizeWithNegative: (bytes: any, zeroToEmpty?: boolean, type?: string) => string;
   formatSpeed: (bytes: any, zeroToEmpty: boolean) => string;
   parseURL: (
     url: string
@@ -200,6 +201,26 @@ export const filters: IFilter = {
     }
 
     return this.formatNumber(r, format) + u;
+  },
+
+  /**
+   * 支持负值
+   */
+  formatSizeWithNegative(
+    sourceBytes: any,
+    zeroToEmpty: boolean = false,
+    type: string = ""
+  ): string {
+    sourceBytes = parseFloat(sourceBytes)
+    let bytes = sourceBytes
+    if (sourceBytes < 0) {
+      bytes = - bytes
+    }
+    let result = this.formatSize(bytes, zeroToEmpty, type)
+    if (sourceBytes < 0) {
+      result = `- ${result}`
+    }
+    return result
   },
 
   /**


### PR DESCRIPTION
之前显示: `N/A`
现在:

<img width="320" alt="Screen Shot 2021-07-27 at 9 47 36 AM" src="https://user-images.githubusercontent.com/2525544/127082467-7e12f937-2d10-47c6-aa58-815eae9c7a0f.png">
