### PR TITLE
fix: disable message count display

### DIFF
--- a/resource/i18n/en.json
+++ b/resource/i18n/en.json
@@ -658,7 +658,7 @@
           "priorityTip": "Can be used for search sorting",
           "offline": "Site is offline (downtime\/shutdown)",
           "timezone": "Timezone",
-          "messageCountToggle": "Display message count"
+          "disableMessageCount": "Display message count"
         },
         "index": {
           "importAll": "One-click import site",

--- a/resource/i18n/zh-CN.json
+++ b/resource/i18n/zh-CN.json
@@ -658,7 +658,7 @@
           "priorityTip": "可用于搜索排序",
           "offline": "站点已离线（停机/关闭）",
           "timezone": "时区",
-          "messageCountToggle": "消息提醒 (打开/关闭)"
+          "disableMessageCount": "关闭消息提醒"
         },
         "index": {
           "importAll": "一键导入站点",

--- a/src/interface/common.ts
+++ b/src/interface/common.ts
@@ -266,7 +266,7 @@ export interface Site {
   // 是否合并 Schema 的标签选择器
   mergeSchemaTagSelectors?: boolean;
   // 消息提醒开关
-  messageCountToggle?: boolean;
+  disableMessageCount?: boolean;
 }
 
 export interface Request {

--- a/src/options/views/Home.vue
+++ b/src/options/views/Home.vue
@@ -82,7 +82,7 @@
             <v-badge color="red messageCount" overlap>
               <template
                 v-slot:badge
-                v-if="props.item.messageCountToggle && props.item.user.messageCount > 0"
+                v-if="!props.item.disableMessageCount && props.item.user.messageCount > 0"
                 :title="$t('home.newMessage')"
               >
                 {{

--- a/src/options/views/settings/Sites/Editor.vue
+++ b/src/options/views/settings/Sites/Editor.vue
@@ -172,7 +172,7 @@
         <v-switch :label="$t('settings.sites.editor.offline')" v-model="site.offline"></v-switch>
 
         <!-- 消息提醒开关 -->
-        <v-switch :label="$t('settings.sites.editor.messageCountToggle')" v-model="site.messageCountToggle"></v-switch>
+        <v-switch :label="$t('settings.sites.editor.disableMessageCount')" v-model="site.disableMessageCount"></v-switch>
       </v-form>
     </v-card-text>
   </v-card>
@@ -368,9 +368,7 @@ export default Vue.extend({
     },
     initData() {
       if (this.initData) {
-        this.site = Object.assign({
-          messageCountToggle: true,
-        }, this.initData);
+        this.site = Object.assign({}, this.initData);
         this.valid = this.site.name && this.site.host ? true : false;
       }
     }


### PR DESCRIPTION
Fix #841, 已添加站点里面没有`messageCountToggle: true`值, 导致升级之后所有站点都不显示消息提醒了.