### PR TITLE
fix: #713 柠檬副标题做种状态free标签问题

### DIFF
--- a/resource/sites/lemonhd.org/config.json
+++ b/resource/sites/lemonhd.org/config.json
@@ -67,7 +67,7 @@
     "fieldSelector": {
       "progress": {
         "selector": [
-          "> td:eq(8)"
+          "> td:eq(9)"
         ],
         "filters": [
           "query.text()==='--'?null:parseFloat(query.text())"
@@ -75,7 +75,7 @@
       },
       "status": {
         "selector": [
-          "> td:eq(8)"
+          "> td:eq(9)"
         ],
         "filters": [
           "query.text()==='--'?null:query.is('.peer-active')?(parseFloat(query.text())==100?2:1):(parseFloat(query.text())==100?255:3)"
@@ -85,42 +85,42 @@
   },
   "searchEntry": [
     {
-      "entry": "/torrents.php?search_area=name&search=$key$",
+      "entry": "/torrents.php?search=$key$",
       "name": "全站",
       "enabled": true
     },
     {
-      "entry": "/torrents.php?search=$key$",
+      "entry": "/torrents_movie.php?stype=s&search=$key$",
       "name": "电影",
       "enabled": false
     },
     {
-      "entry": "/torrents_tv.php?search=$key$",
+      "entry": "/torrents_tv.php?stype=s&search=$key$",
       "name": "电视综艺",
       "enabled": false
     },
     {
-      "entry": "/torrents_music.php?search=$key$",
+      "entry": "/torrents_music.php?stype=s&search=$key$",
       "name": "音乐",
       "enabled": false
     },
     {
-      "entry": "/torrents_animate.php?search=$key$",
+      "entry": "/torrents_animate.php?stype=s&search=$key$",
       "name": "动漫",
       "enabled": false
     },
     {
-      "entry": "/torrents_mv.php?search=$key$",
+      "entry": "/torrents_mv.php?stype=s&search=$key$",
       "name": "MV",
       "enabled": false
     },
     {
-      "entry": "/torrents_doc.php?search=$key$",
+      "entry": "/torrents_doc.php?stype=s&search=$key$",
       "name": "纪录片",
       "enabled": false
     },
     {
-      "entry": "/torrents_other.php?search=$key$",
+      "entry": "/torrents_other.php?stype=s&search=$key$",
       "name": "其他",
       "enabled": false
     }

--- a/resource/sites/lemonhd.org/getSearchResult.js
+++ b/resource/sites/lemonhd.org/getSearchResult.js
@@ -197,7 +197,7 @@
             comments:
               this.getFieldValue(row, cells, fieldIndex, "comments") || 0,
             site: site,
-            tags: Searcher.getRowTags(this.site, row),
+            tags: this.getRowTags(row),
             entryName: options.entry.name,
             category:
               fieldIndex.category == -1
@@ -349,25 +349,27 @@
       try {
         subTitle = title
           .parent()
-          .html()
-          .split("<br>");
-        if (subTitle && subTitle.length > 1) {
-          subTitle = $("<span>")
-            .html(subTitle[subTitle.length - 1])
-            .text();
-        } else {
-          // 特殊情况处理
-          switch (options.site.host) {
-            default:
-              subTitle = "";
-              break;
-          }
-        }
-
+          .next()
+          .text();
         return subTitle || "";
       } catch (error) {
         return "";
       }
+    }
+
+    getRowTags(row) {
+      let tags = []
+      try {
+        if (row.text().trim().match(/免费剩余/)) {
+          tags.push({
+            name: "~Free",
+            color: "teal"
+          })
+        };
+      } catch (error) {
+        return [];
+      }
+      return tags;
     }
 
     // 很


### PR DESCRIPTION
修复了柠檬站点副标题不显示的问题
添加了柠檬站点的限时免费标签的显示
修复了柠檬站点做种状态的显示