### PR TITLE
feat: 添加某R做种信息

### DIFF
--- a/resource/sites/hdroute.org/config.json
+++ b/resource/sites/hdroute.org/config.json
@@ -100,6 +100,16 @@
           "filters": ["query.next().text().match(/([\\d.]+ ?[ZEPTGMK]?i?B)/)", "(query && query.length==2)?(query[1]).sizeToNumber():0"]
         }
       }
+    },
+    "userSeedingTorrents": {
+      "page": "/api.php?action=getAllPeeringInfo",
+      "dataType": "json",
+      "fields": {
+        "seedingList": {
+          "selector": ["seeding"],
+          "filters": ["let r=[];query.forEach(q=>{r.push(q.torrentid)});r"]
+        }
+      }
     }
   }
 }

--- a/resource/sites/hdroute.org/getSearchResult.js
+++ b/resource/sites/hdroute.org/getSearchResult.js
@@ -42,6 +42,7 @@
           let link = `${site.url}details.php?id=${id}`;
 
           let data = {
+            id,
             title: row.find(".title_chs").text(),
             subTitle: row.find(".title_eng").text(),
             link,

--- a/resource/sites/passthepopcorn.me/config.json
+++ b/resource/sites/passthepopcorn.me/config.json
@@ -77,8 +77,18 @@
         }
       }
     },
+    "userSeedingTorrents": {
+      "page": "/torrents.php?type=seeding&userid=$user.id$",
+      "parser": "getUserSeedingTorrents.js",
+      "fields": {
+        "seedingList": {
+          "selector": ["script:last"],
+          "filters": ["query.text()", "[...query.matchAll(/\"TorrentId\":(\\d+)/g)]", "jQuery.map(query, i=>i[1])"]
+        }
+      }
+    },
     "common": {
-	  "page": "/torrents.php",
+	    "page": "/torrents.php",
       "fields": {
         "confirmSize": {
           "selector": ["tr.basic-movie-list__torrent-row > td:contains('iB')"],

--- a/resource/sites/passthepopcorn.me/getSearchResult.js
+++ b/resource/sites/passthepopcorn.me/getSearchResult.js
@@ -50,6 +50,7 @@ if (!"".getQueryString) {
           let row = Movies[index];
           let torrent = row.Torrents[0];
           let data = {
+            id: `${torrent.Id}`,
             title:
               row.Title +
               "[" +

--- a/resource/sites/passthepopcorn.me/getUserSeedingTorrents.js
+++ b/resource/sites/passthepopcorn.me/getUserSeedingTorrents.js
@@ -1,0 +1,113 @@
+(function(options, User) {
+  class Parser {
+    constructor(options, dataURL) {
+      this.options = options;
+      this.dataURL = dataURL;
+      this.body = null;
+      this.rawData = "";
+      this.pageInfo = {
+        count: 0,
+        current: 1
+      };
+      this.result = {
+        seedingList: []
+      };
+      this.load();
+    }
+
+    /**
+     * 完成
+     */
+    done() {
+      this.options.resolve(this.result);
+    }
+
+    /**
+     * 解析内容
+     */
+    parse() {
+      const doc = new DOMParser().parseFromString(this.rawData, "text/html");
+      // 构造 jQuery 对象
+      this.body = $(doc).find("body");
+
+      this.getPageInfo();
+
+      let results = new User.InfoParser(User.service).getResult(
+        this.body,
+        this.options.rule
+      );
+
+      if (results) {
+        this.result.seedingList = this.result.seedingList.concat(results.seedingList)
+      }
+
+      // 是否已到最后一页
+      if (this.pageInfo.current < this.pageInfo.count) {
+        this.pageInfo.current++;
+        this.load();
+      } else {
+        this.done();
+      }
+    }
+
+    /**
+     * 获取页面相关内容
+     */
+    getPageInfo() {
+      if (this.pageInfo.count > 0) {
+        return;
+      }
+      // 获取最大页码
+      const infos = this.body
+        .find("a[href*='torrents.php?page=']:contains('Last'):last")
+        .attr("href");
+
+      if (infos) {
+        this.pageInfo.count = parseInt(infos.getQueryString("page"));
+      } else {
+        this.pageInfo.count = 2;
+      }
+    }
+
+    /**
+     * 加载当前页内容
+     */
+    load() {
+      let url = this.dataURL;
+      if (this.pageInfo.current > 1) {
+        url += "&page=" + this.pageInfo.current;
+      }
+      $.get(url)
+        .done(result => {
+          this.rawData = result;
+          this.parse();
+        })
+        .fail(() => {
+          this.done();
+        });
+    }
+  }
+
+  let dataURL = options.site.activeURL + options.rule.page;
+  dataURL = dataURL
+    .replace("$user.id$", options.userInfo.id)
+    .replace("$user.name$", options.userInfo.name)
+    .replace("://", "****")
+    .replace(/\/\//g, "/")
+    .replace("****", "://");
+
+  new Parser(options, dataURL);
+})(_options, _self);
+/**
+ * 
+  _options 表示当前参数 
+  {
+    site,
+    rule,
+    userInfo,
+    resolve,
+    reject
+  }
+
+  _self 表示 User(/src/background/user.ts) 类实例 
+ */

--- a/resource/sites/uhdbits.org/config.json
+++ b/resource/sites/uhdbits.org/config.json
@@ -70,6 +70,10 @@
         "seedingSize": {
           "selector": ["td.number_column.nobr"],
           "filters": ["jQuery.map(query, (item)=>{return $(item).text();})", "_self.getTotalSize(query)"]
+        },
+        "seedingList": {
+          "selector": ["a[href*='torrentid=']"],
+          "filters": ["jQuery.map(query, item=>$(item).attr('href').match(/torrentid=(\\d+)/)[1])"]
         }
       }
     }

--- a/resource/sites/uhdbits.org/getSearchResult.js
+++ b/resource/sites/uhdbits.org/getSearchResult.js
@@ -72,6 +72,9 @@ if (!"".getQueryString) {
           const row = rows.eq(index);
           let cells = row.find(">td");
 
+          let id = row.find("a[href*='#torrent']").first()
+          id = id.attr('href').match(/#torrent(\d+)/)[1]
+
           let title = row.find("a[href*='torrents.php?id=']").first();
           if (title.length == 0) {
             continue;
@@ -113,6 +116,7 @@ if (!"".getQueryString) {
           }
 
           let data = {
+            id,
             title: title.text() + ' / ' +subTitle.text(),
             //subTitle: subTitle.text(),
             link,

--- a/resource/sites/uhdbits.org/getUserSeedingTorrents.js
+++ b/resource/sites/uhdbits.org/getUserSeedingTorrents.js
@@ -23,7 +23,8 @@ if ("".getQueryString === undefined) {
       };
       this.result = {
         seedingSize: 0,
-        bonus: 0
+        bonus: 0,
+        seedingList: []
       };
       this.load();
     }
@@ -52,6 +53,7 @@ if ("".getQueryString === undefined) {
 
       if (results) {
         this.result.seedingSize += results.seedingSize;
+        this.result.seedingList = this.result.seedingList.concat(results.seedingList)
       }
 
       // 是否已到最后一页

--- a/src/interface/common.ts
+++ b/src/interface/common.ts
@@ -522,6 +522,8 @@ export interface UserInfo {
   seeding?: number;
   // 做种体积
   seedingSize?: number;
+  // 做种列表
+  seedingList?: string[];
   // 当前下载数量
   leeching?: number;
   // 等级名称

--- a/src/interface/common.ts
+++ b/src/interface/common.ts
@@ -340,6 +340,7 @@ export interface SearchResultItemCategory {
  * 搜索返回结果
  */
 export interface SearchResultItem {
+  id?: string;
   site: Site;
   title: string;
   titleHTML?: string;

--- a/src/options/views/search/SearchTorrent.ts
+++ b/src/options/views/search/SearchTorrent.ts
@@ -843,6 +843,18 @@ export default Vue.extend({
           }
         }
 
+        if (!item.progress && !item.status) {
+          // 对比用户信息的seedingList修改做种状态信息
+          if (item.site && item.site.user && item.site.user.seedingList) {
+            let seedingList = item.site.user.seedingList;
+            let seeding = seedingList.some(id => item.id && item.id == id);
+            if (seeding) {
+              item.progress = 100;
+              item.status = 2;
+            }
+          }
+        }
+
         if (dayjs(item.time).isValid()) {
           let val: number | string = item.time + "";
           // 标准时间戳需要 * 1000


### PR DESCRIPTION
https://github.com/ronggang/PT-Plugin-Plus/projects/1#card-21167843

这次是根据功能计划里面的2.0修改的。

主要改动:
`UserInfo` 接口加了一个 `seedingList`，记录做种信息
`SearchResultItem` 接口加了一个 `id`，方便标记
对应站点在 `config` 文件中 `userSeedingTorrents.fields.seedingList` 中设置做种列表的解析方法（部分站点可能要新开一种不同于`userSeedingTorrents`的方法来解析）
对应搜索结果解析的时候加上种子 `id` 的信息
UI 界面添加检查种子`id` 是否在 `seedingList` 来决定是否显示做种的逻辑

预期效果：
获取站点信息的同时，获取做种列表
搜索结果根据做种列表标记做种中的种子

目前某R的修改效果已经达到，有没有其他bug待测试。