### PR TITLE
fix: google fonts page broken in Firefox

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -46,6 +46,9 @@
 			"http://*/*",
 			"https://*/*"
 		],
+		"exclude_matches": [
+			"https://fonts.google.com/*"
+		],
 		"css": [
 			"assets/base.css",
 			"libs/materialIcons/content_style.css",


### PR DESCRIPTION
<!-- 
感谢您提交 PR ，为了更好的进行版本迭代，请将目标分支选择为 `base:dev` ，我们会根据实际情况在后续版本中发布。

## 标题请尽量按以下格式进行描述

`<type>(<scope>): <subject>`

## type 说明

- feat: 添加新功能
- fix: 修补 bug
- docs: 文档（documentation）
- style: 格式（不影响代码运行的变动）
- refactor: 重构（即不是新增功能，也不是修改 bug 的代码变动）
- test: 增加测试
- chore: 构建过程或辅助工具的变动

## 参考文档：http://www.ruanyifeng.com/blog/2016/01/commit_message_change_log.html

## 内容说明

请尽量详细描述本次 PR 的具体作用。

本内容仅供提交前查阅，提交时请务必删除这段内容。
本内容仅供提交前查阅，提交时请务必删除这段内容。
本内容仅供提交前查阅，提交时请务必删除这段内容。
 -->

Open Firefox, open https://fonts.google.com/icons?selected=Material+Icons, the page is broken, caused by PT Plugin Plus

<img width="474" alt="Screen Shot 2021-08-22 at 11 15 10 AM" src="https://user-images.githubusercontent.com/2525544/130340828-aa590dc1-4416-4269-b11d-8497eb911647.png">

