### PR TITLE
fix: English translation for searchTorrent.headers.comments

### DIFF
--- a/resource/i18n/en.json
+++ b/resource/i18n/en.json
@@ -273,6 +273,7 @@
         "seeders": "S",
         "leechers": "L",
         "completed": "C",
+        "comments": "Comments",
         "time": "Time(≈)",
         "action": "Action"
       },

--- a/resource/i18n/zh-CN.json
+++ b/resource/i18n/zh-CN.json
@@ -272,9 +272,9 @@
         "seeders": "上传",
         "leechers": "下载",
         "completed": "完成",
+        "comments": "评论",
         "time": "发布于(≈)",
-        "action": "操作",
-        "comments": "评论"
+        "action": "操作"
       },
       "optionsIsMissing": "系统参数丢失",
       "sitesIsMissing": "请先设置站点",


### PR DESCRIPTION
Translation fix.

Was:

![image](https://user-images.githubusercontent.com/5752560/136565370-f488a357-cba8-495a-a0a7-901858697057.png)

Now:

![image](https://user-images.githubusercontent.com/5752560/136565500-99428e16-9598-4da8-a83f-813095067a00.png)
