### PR TITLE
提高GazelleJSONAPI选择器精度

### DIFF
--- a/resource/schemas/GazelleJSONAPI/config.json
+++ b/resource/schemas/GazelleJSONAPI/config.json
@@ -63,7 +63,7 @@
       "page": "/torrents.php?type=seeding&userid=$user.id$",
       "fields": {
         "seedingSize": {
-          "selector": ["tr.torrent_row > td.nobr"],
+          "selector": ["tr.torrent_row > td.number_column.nobr"],
           "filters": ["jQuery.map(query, (item)=>{return $(item).text();})", "_self.getTotalSize(query)"]
         },
         "bonus": {


### PR DESCRIPTION
- fix: 提高选择器精度，避免选中日期列导致某些自定义站点做种体积出错。