### PR TITLE
fix(pttime): error count for seeding (still error for seeding size)

### DIFF
--- a/resource/sites/www.pttime.org/config.json
+++ b/resource/sites/www.pttime.org/config.json
@@ -6,5 +6,85 @@
   "description": "PT时间",
   "icon": "https://www.pttime.org/favicon.ico",
   "tags": ["电影", "成人"],
-  "host": "www.pttime.org"
+  "host": "www.pttime.org",
+  "selectors": {
+    "userBaseInfo": {
+      "page": "/index.php",
+      "fields": {
+        "id": {
+          "selector": ["a[href*='userdetails.php'][class*='Name']:first", "a[href*='userdetails.php']:first"],
+          "attribute": "href",
+          "filters": ["query ? query.getQueryString('id'):''"]
+        },
+        "name": {
+          "selector": ["a[href*='userdetails.php'][class*='Name']:first", "a[href*='userdetails.php']:first"],
+          "filters": ["query && query.attr('href').getQueryString('id') > 0 ? query.text(): ''"]
+        },
+        "isLogged": {
+          "selector": ["a[href*='usercp.php']"],
+          "filters": ["query.length>0"]
+        },
+        "messageCount": {
+          "selector": ["td[style*='background: red'] a[href*='messages.php']"],
+          "filters": ["query.text().match(/(\\d+)/)", "(query && query.length>=2)?parseInt(query[1]):0"]
+        },
+        "seeding": {
+          "selector": ["font.color_active"],
+          "filters": ["query.parent().text().match(/\\d+(\\.\\d+)?/g)", "parseInt(query[0])"]
+        }
+      }
+    },
+    "userExtendInfo": {
+      "page": "/userdetails.php?id=$user.id$",
+      "fields": {
+        "uploaded": {
+          "selector": ["td.rowhead:contains('传输') + td", "td.rowhead:contains('傳送') + td", "td.rowhead:contains('Transfers') + td", "td.rowfollow:contains('分享率')"],
+          "filters": ["query.text().replace(/,/g,'').match(/(上[传傳]量|Uploaded).+?([\\d.]+ ?[ZEPTGMK]?i?B)/)", "(query && query.length==3)?(query[2]).sizeToNumber():0"]
+        },
+        "downloaded": {
+          "selector": ["td.rowhead:contains('传输') + td", "td.rowhead:contains('傳送') + td", "td.rowhead:contains('Transfers') + td", "td.rowfollow:contains('分享率')"],
+          "filters": ["query.text().replace(/,/g,'').match(/(下[载載]量|Downloaded).+?([\\d.]+ ?[ZEPTGMK]?i?B)/)", "(query && query.length==3)?(query[2]).sizeToNumber():0"]
+        },
+        "levelName": {
+          "selector": ["td.rowhead:contains('等级')", "td.rowhead:contains('等級')", "td.rowhead:contains('Class')"],
+          "filters": ["query.next().find('img').attr('title')"]
+        },
+        "bonus": {
+          "selector": ["td.rowhead:contains('魔力') + td", "td.rowhead:contains('Karma'):contains('Points') + td", "td.rowhead:contains('麦粒') + td", "td.rowfollow:contains('魔力值')"],
+          "filters": ["query.is(\":contains('魔力值:')\")?query.text().replace(/,/g,'').match(/魔力值.+?([\\d.]+)/)[1]:query.text().replace(/,/g,'')", "parseFloat(query)"]
+        },
+        "joinTime": {
+          "selector": ["td.rowhead:contains('加入日期')", "td.rowhead:contains('Join'):contains('date')"],
+          "filters": ["query.next().text().split(' (')[0]", "dateTime(query).isValid()?dateTime(query).valueOf():query"]
+        }
+      }
+    },
+    "userSeedingTorrents": {
+      "page": "/getusertorrentlistajax.php?userid=$user.id$&type=seeding",
+      "fields": {
+        "seedingSize": {
+          "selector": ["tr:not(:eq(0))"],
+          "filters": ["jQuery.map(query.find('td.rowfollow:eq(2)'), (item)=>{return $(item).text();})", "_self.getTotalSize(query)"]
+        }
+      }
+    },
+    "/details.php": {
+      "fields": {
+        "size": {
+          "selector": ["b:contains('大小'):first"],
+          "filters": ["query.parent().text().replace(/,/g,'').match(/([\\d.]+ ?[ZEPTGMK]?i?B)/)", "(query && query.length>1)?(query[1]).sizeToNumber():0"]
+        },
+        "imdbId": {
+          "selector": ["a[href*='www.imdb.com/title/']:first"],
+          "attribute": "href",
+          "filters": ["query.match(/(tt\\d+)/)", "(query && query.length>=2)?query[1]:null"]
+        },
+        "sayThanksButton": {
+          "selector": ["input#saythanks:not(:disabled)"],
+          "filters": ["query"]
+        }
+      }
+    }
+  },
+  "collaborator": "asterisk"
 }


### PR DESCRIPTION
## type

- fix #954: error count for seeding (still error for seeding size)

## 说明

将做种数(seeding)替换为首页`当前活动`所显示的数字以避免个人信息页只显示20条信息所造成的计数错误

![image](https://user-images.githubusercontent.com/44529210/155514680-26266892-839f-4d0d-8484-4ea1ecccd19c.png)

**但由于无法通过其他方式获得具体的大小，做种体积(seedingsize)仍受个人信息页限制（只显示20条），需网站维护者解决。**

![image](https://user-images.githubusercontent.com/44529210/155515378-c3efab24-3eee-44d8-b119-be6037e0165a.png)
