### PR TITLE
feat: 搜索结果副标题增加 title 属性以便查看全部

### DIFF
--- a/src/options/views/search/SearchTorrent.vue
+++ b/src/options/views/search/SearchTorrent.vue
@@ -614,7 +614,7 @@
                 >{{ tag.name }}</span>
               </span>
 
-              <span v-if="props.item.subTitle">{{ props.item.subTitle }}</span>
+              <span v-if="props.item.subTitle" :title="props.item.subTitle">{{ props.item.subTitle }}</span>
             </div>
 
             <v-layout v-if="$vuetify.breakpoint.xs">


### PR DESCRIPTION
如果副标题内容过长，无法查看全部内容