### PR TITLE
修复CG中文搜索时返回不相关结果的bug

### DIFF
--- a/resource/sites/cinemageddon.net/getSearchResult.js
+++ b/resource/sites/cinemageddon.net/getSearchResult.js
@@ -1,3 +1,15 @@
+if (!"".getQueryString) {
+  String.prototype.getQueryString = function(name, split) {
+    if (split == undefined) split = "&";
+    var reg = new RegExp(
+        "(^|" + split + "|\\?)" + name + "=([^" + split + "]*)(" + split + "|$)"
+      ),
+      r;
+    if ((r = this.match(reg))) return decodeURI(r[2]);
+    return null;
+  };
+}
+
 (function(options) {
   class Parser {
     constructor() {
@@ -26,7 +38,10 @@
       let results = [];
       // 获取种子列表行
       let rows = options.page.find(options.resultSelector);
-      if (rows.length == 0) {
+      const browsecheck = options.page
+        .find("a[href*='browse.php?page']:contains('-'):last")
+        .attr("href");
+      if (rows.length == 0 || browsecheck) {
         options.status = ESearchResultParseStatus.torrentTableIsEmpty; //`[${options.site.name}]没有定位到种子列表，或没有相关的种子`;
         return results;
       }


### PR DESCRIPTION
## type 说明

- fix: 修复CG中文搜索时返回不相关结果的bug

## 内容说明
当搜索中文字符时，CG默认回到browse页，导致结果提取器错误提取全部browse页种子。特征为browse页翻页href中缺少`search`。
注：代码开头加入了getQueryString，原本是打算通过page的值来判断的，没有采用，忘了删，懒得重新提交了，留着也不碍事。

