### PR TITLE
fix: 修复白兔做种体积无法显示

### DIFF
--- a/resource/sites/club.hares.top/config.json
+++ b/resource/sites/club.hares.top/config.json
@@ -179,13 +179,18 @@
             ".layui-row.layui-userdetails.layui-poll-con.layui-margin-bottom table tbody td:eq(8)"
           ],
           "filters": [ "query.html()" ]
-        },
+        }
+      }
+    },
+    "userSeedingTorrents": {
+      "page": "/getusertorrentlistajax.php?page=1&limit=50&uid=$user.id$&type=seeding",
+      "parser": "getUserSeedingTorrents.js",
+      "fields": {
         "seeding": {
-          "selector": [ "i.fas.fa-upload.text-success.fa-fw + span.list-info" ],
-          "filters": ["query.text().trim()"]
+          "selector": ["div"]
         },
         "seedingSize": {
-          "value": -1
+          "selector": ["div"]
         }
       }
     }

--- a/resource/sites/club.hares.top/getUserSeedingTorrents.js
+++ b/resource/sites/club.hares.top/getUserSeedingTorrents.js
@@ -1,0 +1,79 @@
+if ("".getQueryString === undefined) {
+  String.prototype.getQueryString = function(name, split) {
+    if (split == undefined) split = "&";
+    var reg = new RegExp(
+        "(^|" + split + "|\\?)" + name + "=([^" + split + "]*)(" + split + "|$)"
+      ),
+      r;
+    if ((r = this.match(reg))) return decodeURI(r[2]);
+    return null;
+  };
+}
+
+(function(options, User) {
+  class Parser {
+    constructor(options, dataURL) {
+      this.options = options;
+      this.dataURL = dataURL;
+      this.body = null;
+      this.rawData = "";
+      this.pageInfo = {
+        count: 0,
+        current: 0
+      };
+      this.result = {
+        seeding: 0,
+        seedingSize: 0
+      };
+      this.load();
+    }
+
+    parse(result) {
+      var jsonObject= JSON.parse(result);
+
+      let results = new User.InfoParser(User.service);
+      if (results) {
+        this.result.seeding = jsonObject.count;
+        this.result.seedingSize = jsonObject.size.sizeToNumber();
+      }
+      
+      this.options.resolve(this.result);
+    }
+
+    load() {
+        $.ajax({
+          url: this.dataURL,
+          headers: {
+              Accept: "application/json, text/javascript, */*; q=0.01"
+          },
+          type: "get",
+          success: (data)=>{
+            this.parse(data);
+          }
+      })
+    }
+  }
+
+  let dataURL = options.site.activeURL + options.rule.page;
+  dataURL = dataURL
+    .replace("$user.id$", options.userInfo.id)
+    .replace("$user.name$", options.userInfo.name)
+    .replace("://", "****")
+    .replace(/\/\//g, "/")
+    .replace("****", "://");
+
+  new Parser(options, dataURL);
+})(_options, _self);
+/**
+ * 
+  _options 表示当前参数 
+  {
+    site,
+    rule,
+    userInfo,
+    resolve,
+    reject
+  }
+
+  _self 表示 User(/src/background/user.ts) 类实例 
+ */


### PR DESCRIPTION
解决这个问题[白兔俱乐部不显示做种体积和数量](https://github.com/ronggang/PT-Plugin-Plus/issues/1134)
研究了一下白兔并没有限制获取数据，我自己测试已经能正常获取到
