### PR TITLE
fix: 搜索框手机端回车按钮修改为搜索

### DIFF
--- a/src/options/components/SearchBox.vue
+++ b/src/options/components/SearchBox.vue
@@ -14,6 +14,7 @@
         @click.stop="showSelectBox"
         @click:clear="clearSearchKey"
         :loading="loadStatus"
+        enterkeyhint="search"
         v-on:keyup.enter="searchTorrent()"
       >
         <!-- 近期热门 -->

--- a/src/options/views/Home.vue
+++ b/src/options/views/Home.vue
@@ -63,6 +63,7 @@
           label="Search"
           single-line
           hide-details
+          enterkeyhint="search"
         ></v-text-field>
       </v-card-title>
 

--- a/src/options/views/search/SearchTorrent.vue
+++ b/src/options/views/search/SearchTorrent.vue
@@ -300,6 +300,7 @@
               :label="$t('searchTorrent.filterSearchResults')"
               single-line
               hide-details
+              enterkeyhint="search"
             ></v-text-field>
           </div>
         </v-flex>


### PR DESCRIPTION
修改了头部搜索框/我的数据搜索框/搜索结果过滤输入框在手机上输入法回车键的表现, 默认现在是 `next` (切换到下一个, 相当于 `tab`), 现在修正为 `search`.
未修复前按回车按钮会切换到下一个输入框, 现在按回车可以直接搜索.
PS: 没修复的话, 需要切换非标准输入法, 然后点回车后再切换标准输入法. 