### PR TITLE
修改记录：

### DIFF
--- a/resource/sites/audiences.me/config.json
+++ b/resource/sites/audiences.me/config.json
@@ -14,6 +14,22 @@
   "schema": "NexusPHP",
   "host": "audiences.me",
   "collaborator": "Audiences",
+  "selectors": {
+    "userExtendInfo": {
+        "page": "/userdetails.php?id=$user.id$",
+        "merge": true,
+        "fields": {
+          "bonus2": {
+            "selector": ["td.rowhead:contains('做种积分') + td"],
+            "filters": [
+              "query.text().match(/(.*?)本月：/g)",
+              "(query && query.length>0) ? query[0].replace('（本月：', '').trim() : 0",
+              "(query != 0) ? parseFloat(query) : 0"
+          ]
+          }
+        }
+    }
+  },
   "searchEntryConfig": {
     "fieldSelector": {
       "progress": {

--- a/resource/sites/carpt.net/config.json
+++ b/resource/sites/carpt.net/config.json
@@ -1,0 +1,44 @@
+{
+    "name": "CarPT",
+    "timezoneOffset": "+0800",
+    "description": "CarPT",
+    "url": "https://carpt.net/",
+    "icon": "https://carpt.net/favicon.ico",
+    "tags": [],
+    "schema": "NexusPHP",
+    "host": "carpt.net",
+    "collaborator": "koal",
+    "selectors": {
+        "userExtendInfo": {
+            "page": "/userdetails.php?id=$user.id$",
+            "merge": true,
+            "fields": {
+              "bonus2": {
+                "selector": ["td.rowhead:contains('做种积分') + td"],
+                "filters": ["query.text().replace(/,/g,'')", "parseFloat(query)"]
+              }
+            }
+        },
+        "userSeedingTorrents": {
+            "page": "/getusertorrentlistajax.php?userid=$user.id$&type=seeding",
+            "fields": {
+                "seeding": {
+                    "selector": [
+                        "b:first"
+                    ],
+                    "filters": [
+                        "query.text()"
+                    ]
+                },
+                "seedingSize": {
+                    "selector": "",
+                    "filters": [
+                        "query.text().match(/总大小：(.*?)上一页/g)",
+                        "(query && query.length>0) ? query[0].replace('总大小：', '').replace('<< 上一页', '').trim() : 0",
+                        "(query != 0) ? query.sizeToNumber() : 0"
+                    ]
+                }
+            }
+        }
+    }
+}

--- a/resource/sites/chdbits.co/config.json
+++ b/resource/sites/chdbits.co/config.json
@@ -117,6 +117,18 @@
     "name": "50%",
     "selector": "img.pro_50pctdown"
   }],
+  "selectors": {
+      "userExtendInfo": {
+          "page": "/userdetails.php?id=$user.id$",
+          "merge": true,
+          "fields": {
+            "bonus2": {
+              "selector": ["td.rowhead:contains('传输') + td", "td.rowhead:contains('傳送') + td", "td.rowhead:contains('Transfers') + td", "td.rowfollow:contains('分享率')"],
+              "filters": ["query.text().replace(/,/g,'').match(/(做种积分).+?([\\d.]+)/)", "(query && query.length==3)? query[2]:0",  "(query != 0) ? parseFloat(query) : 0"]
+            }
+          }
+      }
+  },
   "searchEntryConfig": {
 	"merge": true,
     "fieldSelector": {

--- a/resource/sites/gainbound.net/config.json
+++ b/resource/sites/gainbound.net/config.json
@@ -6,6 +6,39 @@
     "tags": ["高清","电影","纪录片"],
     "schema": "NexusPHP",
     "host": "gainbound.net",
+    "selectors": {
+      "userExtendInfo": {
+        "page": "/userdetails.php?id=$user.id$",
+        "merge": true,
+        "fields": {
+          "bonus2": {
+            "selector": ["td.rowhead:contains('做种积分') + td"],
+            "filters": ["query.text().replace(/,/g,'')", "parseFloat(query)"]
+          }
+        }
+    },
+        "userSeedingTorrents": {
+            "page": "/getusertorrentlistajax.php?userid=$user.id$&type=seeding",
+            "fields": {
+                "seeding": {
+                    "selector": [
+                        "b:first"
+                    ],
+                    "filters": [
+                        "query.text()"
+                    ]
+                },
+                "seedingSize": {
+                    "selector": "",
+                    "filters": [
+                      "query.text().match(/总大小：(.*?)上一页/g)",
+                      "(query && query.length>0) ? query[0].replace('总大小：', '').replace('<< 上一页', '').trim() : 0",
+                      "(query != 0) ? query.sizeToNumber() : 0"
+                  ]
+                }
+            }
+        }
+    },
     "patterns": {
       "torrentLinks": ["*://*/*"]
     },

--- a/resource/sites/hdatmos.club/config.json
+++ b/resource/sites/hdatmos.club/config.json
@@ -6,5 +6,17 @@
   "tags": ["影视", "综合"],
   "url": "https://hdatmos.club",
   "host": "hdatmos.club",
-  "collaborator": "luoyefe"
+  "collaborator": "luoyefe",
+  "selectors": {
+    "userExtendInfo": {
+        "page": "/userdetails.php?id=$user.id$",
+        "merge": true,
+        "fields": {
+          "bonus2": {
+            "selector": ["td.rowhead:contains('做种积分') + td"],
+            "filters": ["query.text().replace(/,/g,'')", "parseFloat(query)"]
+          }
+        }
+    }
+  }
 }

--- a/resource/sites/hddolby.com/config.json
+++ b/resource/sites/hddolby.com/config.json
@@ -144,7 +144,21 @@
       ]
     }
   ],
-  "selectors": {
+  "selectors": {    
+    "userExtendInfo": {
+      "page": "/userdetails.php?id=$user.id$",
+        "merge": true,
+        "fields": {
+          "bonus2": {
+            "selector": ["td.rowhead:contains('保种积分') + td"],
+            "filters": [
+              "query.text().match(/(.*?)本月：/g)",
+              "(query && query.length>0) ? query[0].replace('（本月：', '').trim() : 0",
+              "(query != 0) ? parseFloat(query) : 0"
+          ]
+        }
+      }  
+    },
     "/details.php": {
       "merge": true,
       "fields": {

--- a/resource/sites/hdfans.org/config.json
+++ b/resource/sites/hdfans.org/config.json
@@ -25,6 +25,16 @@
           ]
         }
       }
+    },
+    "userExtendInfo": {
+      "page": "/userdetails.php?id=$user.id$",
+      "merge": true,
+      "fields": {
+        "bonus2": {
+          "selector": ["td.rowhead:contains('做种积分') + td"],
+          "filters": ["query.text().replace(/,/g,'')", "parseFloat(query)"]
+        }
+      }
     }
   },
   "searchEntryConfig": {

--- a/resource/sites/hdhome.org/config.json
+++ b/resource/sites/hdhome.org/config.json
@@ -381,6 +381,20 @@
     }
   ],
   "selectors": {
+    "userExtendInfo": {
+      "page": "/userdetails.php?id=$user.id$",
+      "merge": true,
+      "fields": {
+        "bonus2": {
+          "selector": ["td.rowhead:contains('做种积分') + td"],
+          "filters": [
+            "query.text().match(/(.*?)本月：/g)",
+            "(query && query.length>0) ? query[0].replace('（本月：', '').trim() : 0",
+            "(query != 0) ? parseFloat(query) : 0"
+        ]
+        }
+      }
+  },
     "/details.php": {
       "merge": true,
       "fields": {

--- a/resource/sites/hdmayi.com/config.json
+++ b/resource/sites/hdmayi.com/config.json
@@ -1,18 +1,20 @@
 {
-  "name": "1PTBar",
-  "schema": "NexusPHP",
-  "url": "https://1ptba.com/",
-  "description": "壹PT吧,PT下载,教育视频,课件资源,发布教育类,学习类,纪录片等资源",
-  "icon": "https://1ptba.com/kuai360/favicon.ico",
-  "tags": ["影视", "综合"],
-  "host": "1ptba.com",
+    "name": "HDmayi",
+    "timezoneOffset": "+0800",
+    "description": "HDmayi",
+    "url": "http://hdmayi.com/",
+    "icon": "http://hdmayi.com/favicon.ico",
+    "tags": [],
+    "schema": "NexusPHP",
+    "host": "hdmayi.com",
+    "collaborator": "koal",
   "selectors": {
     "userExtendInfo": {
         "page": "/userdetails.php?id=$user.id$",
         "merge": true,
         "fields": {
           "bonus2": {
-            "selector": ["td.rowhead:contains('Seed points') + td"],
+            "selector": ["td.rowhead:contains('做种积分') + td"],
             "filters": ["query.text().replace(/,/g,'')", "parseFloat(query)"]
           }
         }

--- a/resource/sites/hdpt.xyz/config.json
+++ b/resource/sites/hdpt.xyz/config.json
@@ -1,0 +1,171 @@
+{
+    "name": "明教",
+    "timezoneOffset": "+0800",
+    "description": "综合性的PT论坛    欢迎您的加入！",
+    "url": "https://hdpt.xyz/",
+    "icon": "https://hdpt.xyz/favicon.ico",
+    "tags": ["影视", "综合"],
+    "schema": "NexusPHP",
+    "host": "hdpt.xyz",
+    "collaborator": "koal",
+    "selectors": {
+      "userExtendInfo": {
+        "page": "/userdetails.php?id=$user.id$",
+        "merge": true,
+        "fields": {
+          "bonus2": {
+            "selector": ["td.rowhead:contains('做种积分') + td"],
+            "filters": ["query.text().replace(/,/g,'')", "parseFloat(query)"]
+          }
+        }
+    },
+        "userSeedingTorrents": {
+            "page": "/getusertorrentlistajax.php?userid=$user.id$&type=seeding",
+            "fields": {
+                "seeding": {
+                    "selector": [
+                        "b:first"
+                    ],
+                    "filters": [
+                        "query.text()"
+                    ]
+                },
+                "seedingSize": {
+                    "selector": "",
+                    "filters": [
+                        "query.text().match(/总大小：(.*?)上一页/g)",
+                        "(query && query.length>0) ? query[0].replace('总大小：', '').replace('<< 上一页', '').trim() : 0",
+                        "(query != 0) ? query.sizeToNumber() : 0"
+                    ]
+                }
+            }
+        }
+    },
+    "searchEntry": [{
+        "name": "全站",
+        "enabled": true
+      },
+      {
+        "queryString": "cat401=1",
+        "name": "电影",
+        "enabled": false
+      },
+      {
+        "queryString": "cat404=1",
+        "name": "纪录片",
+        "enabled": false
+      },
+      {
+        "queryString": "cat405=1",
+        "name": "动漫",
+        "enabled": false
+      },
+      {
+        "queryString": "cat402=1",
+        "name": "电视剧",
+        "enabled": false
+      },
+      {
+        "queryString": "cat403=1",
+        "name": "综艺",
+        "enabled": false
+      },
+      {
+        "queryString": "cat406=1",
+        "name": "MV",
+        "enabled": false
+      },
+      {
+        "queryString": "cat407=1",
+        "name": "体育",
+        "enabled": false
+      },
+      {
+        "queryString": "cat409=1",
+        "name": "其他",
+        "enabled": false
+      },
+      {
+        "queryString": "cat408=1",
+        "name": "音乐",
+        "enabled": false
+      },
+      {
+        "queryString": "cat410=1",
+        "name": "软件",
+        "enabled": false
+      },
+      {
+        "queryString": "cat411=1",
+        "name": "电子书",
+        "enabled": false
+      },
+      {
+        "queryString": "cat412=1",
+        "name": "卡通",
+        "enabled": false
+      },
+      {
+        "queryString": "cat413=1",
+        "name": "学习资料",
+        "enabled": false
+      }
+    ],
+    "categories": [{
+      "entry": "torrents.php",
+      "result": "&cat$id$=1",
+      "category": [{
+          "id": 401,
+          "name": "电影"
+        },
+        {
+          "id": 404,
+          "name": "纪录片"
+        },
+        {
+          "id": 405,
+          "name": "动漫"
+        },
+        {
+          "id": 402,
+          "name": "电视剧"
+        },
+        {
+          "id": 403,
+          "name": "综艺"
+        },
+        {
+          "id": 406,
+          "name": "MV"
+        },
+        {
+          "id": 407,
+          "name": "体育"
+        },
+        {
+          "id": 409,
+          "name": "其他"
+        },
+        {
+          "id": 408,
+          "name": "音乐"
+        },
+        {
+          "id": 410,
+          "name": "软件"
+        },
+        {
+          "id": 411,
+          "name": "电子书"
+        },
+        {
+          "id": 412,
+          "name": "卡通"
+        },
+        {
+          "id": 413,
+          "name": "学习资料"
+        }
+      ]
+    }]
+}

--- a/resource/sites/hdtime.org/config.json
+++ b/resource/sites/hdtime.org/config.json
@@ -8,6 +8,16 @@
   "schema": "NexusPHP",
   "host": "hdtime.org",
   "selectors": {
+    "userExtendInfo": {
+        "page": "/userdetails.php?id=$user.id$",
+        "merge": true,
+        "fields": {
+          "bonus2": {
+            "selector": ["td.rowhead:contains('做种积分') + td"],
+            "filters": ["query.text().replace(/,/g,'')", "parseFloat(query)"]
+          }
+        }
+    },
     "userSeedingTorrents": {
       "page": "/getusertorrentlistajax.php?userid=$user.id$&type=seeding",
       "fields": {
@@ -18,8 +28,8 @@
         "seedingSize": {
           "selector": "",
           "filters": [
-            "query.text().match(/总大小：(.*?)</g)",
-            "(query && query.length>0 ) ? query[0].replace('总大小：', '').replace('<', '').trim() : 0",
+            "query.text().match(/总大小：(.*?)上一页/g)",
+            "(query && query.length>0) ? query[0].replace('总大小：', '').replace('<< 上一页', '').trim() : 0",
             "(query != 0) ? query.sizeToNumber() : 0"
           ]
         }

--- a/resource/sites/hdvideo.one/config.json
+++ b/resource/sites/hdvideo.one/config.json
@@ -1,0 +1,44 @@
+{
+    "name": "HDVideo",
+    "timezoneOffset": "+0800",
+    "description": "HDVideo",
+    "url": "https://hdvideo.one/",
+    "icon": "https://hdvideo.one/favicon.ico",
+    "tags": [],
+    "schema": "NexusPHP",
+    "host": "hdvideo.one",
+    "collaborator": "koal",
+    "selectors": {
+        "userExtendInfo": {
+            "page": "/userdetails.php?id=$user.id$",
+            "merge": true,
+            "fields": {
+              "bonus2": {
+                "selector": ["td.rowhead:contains('做种积分') + td"],
+                "filters": ["query.text().replace(/,/g,'')", "parseFloat(query)"]
+              }
+            }
+        },
+        "userSeedingTorrents": {
+            "page": "/getusertorrentlistajax.php?userid=$user.id$&type=seeding",
+            "fields": {
+                "seeding": {
+                    "selector": [
+                        "b:first"
+                    ],
+                    "filters": [
+                        "query.text()"
+                    ]
+                },
+                "seedingSize": {
+                    "selector": "",
+                    "filters": [
+                        "query.text().match(/总大小：(.*?)上一页/g)",
+                        "(query && query.length>0) ? query[0].replace('总大小：', '').replace('<< 上一页', '').trim() : 0",
+                        "(query != 0) ? query.sizeToNumber() : 0"
+                    ]
+                }
+            }
+        }
+    }
+}

--- a/resource/sites/hhanclub.top/config.json
+++ b/resource/sites/hhanclub.top/config.json
@@ -1,0 +1,44 @@
+{
+    "name": "憨憨",
+    "timezoneOffset": "+0800",
+    "description": "憨憨",
+    "url": "https://hhanclub.top/",
+    "icon": "https://hhanclub.top/favicon.ico",
+    "tags": [],
+    "schema": "NexusPHP",
+    "host": "hhanclub.top",
+    "collaborator": "koal",
+    "selectors": {
+        "userExtendInfo": {
+            "page": "/userdetails.php?id=$user.id$",
+            "merge": true,
+            "fields": {
+              "bonus2": {
+                "selector": ["td.rowhead:contains('做种积分') + td"],
+                "filters": ["query.text().replace(/,/g,'')", "parseFloat(query)"]
+              }
+            }
+        },
+        "userSeedingTorrents": {
+            "page": "/getusertorrentlistajax.php?userid=$user.id$&type=seeding",
+            "fields": {
+                "seeding": {
+                    "selector": [
+                        "b:first"
+                    ],
+                    "filters": [
+                        "query.text()"
+                    ]
+                },
+                "seedingSize": {
+                    "selector": "",
+                    "filters": [
+                        "query.text().match(/总大小：(.*?)上一页/g)",
+                        "(query && query.length>0) ? query[0].replace('总大小：', '').replace('<< 上一页', '').trim() : 0",
+                        "(query != 0) ? query.sizeToNumber() : 0"
+                    ]
+                }
+            }
+        }
+    }
+}

--- a/resource/sites/ihdbits.me/config.json
+++ b/resource/sites/ihdbits.me/config.json
@@ -1,18 +1,21 @@
 {
-  "name": "1PTBar",
+  "name": "ihdbits",
   "schema": "NexusPHP",
-  "url": "https://1ptba.com/",
-  "description": "壹PT吧,PT下载,教育视频,课件资源,发布教育类,学习类,纪录片等资源",
-  "icon": "https://1ptba.com/kuai360/favicon.ico",
-  "tags": ["影视", "综合"],
-  "host": "1ptba.com",
+  "url": "http://ihdbits.me/",
+  "description": "The Ultimate File Sharing Experience",
+  "icon": "http://ihdbits.me/favicon.ico",
+  "tags": [
+    "影视"
+  ],
+  "host": "ihdbits.me",
+  "collaborator": "koal",
   "selectors": {
     "userExtendInfo": {
         "page": "/userdetails.php?id=$user.id$",
         "merge": true,
         "fields": {
           "bonus2": {
-            "selector": ["td.rowhead:contains('Seed points') + td"],
+            "selector": ["td.rowhead:contains('做种积分') + td"],
             "filters": ["query.text().replace(/,/g,'')", "parseFloat(query)"]
           }
         }

--- a/resource/sites/kamept.com/config.json
+++ b/resource/sites/kamept.com/config.json
@@ -1,0 +1,44 @@
+{
+    "name": "kamept ",
+    "timezoneOffset": "+0800",
+    "description": "kamept",
+    "url": "https://kamept.com/",
+    "icon": "https://kamept.com/favicon.ico",
+    "tags": [],
+    "schema": "NexusPHP",
+    "host": "kamept.com",
+    "collaborator": "koal",
+    "selectors": {
+        "userExtendInfo": {
+            "page": "/userdetails.php?id=$user.id$",
+            "merge": true,
+            "fields": {
+            "bonus2": {
+                "selector": ["td.rowhead:contains('做种积分') + td"],
+                "filters": ["query.text().replace(/,/g,'')", "parseFloat(query)"]
+            }
+            }
+        },
+        "userSeedingTorrents": {
+            "page": "/getusertorrentlistajax.php?userid=$user.id$&type=seeding",
+            "fields": {
+                "seeding": {
+                    "selector": [
+                        "b:first"
+                    ],
+                    "filters": [
+                        "query.text()"
+                    ]
+                },
+                "seedingSize": {
+                    "selector": "",
+                    "filters": [
+                        "query.text().match(/总大小：(.*?)类型/g)",
+                        "(query && query.length>0) ? query[0].replace('总大小：', '').replace('类型', '').trim() : 0",
+                        "(query != 0) ? query.sizeToNumber() : 0"
+                    ]
+                }
+            }
+        }
+    }
+}

--- a/resource/sites/nicept.net/config.json
+++ b/resource/sites/nicept.net/config.json
@@ -9,6 +9,39 @@
   ],
   "schema": "NexusPHP",
   "host": "www.nicept.net",
+  "selectors": {
+    "userExtendInfo": {
+        "page": "/userdetails.php?id=$user.id$",
+        "merge": true,
+        "fields": {
+          "bonus2": {
+            "selector": ["td.rowhead:contains('做種積分') + td"],
+            "filters": ["query.text().replace(/,/g,'')", "parseFloat(query)"]
+          }
+        }
+    },
+      "userSeedingTorrents": {
+          "page": "/getusertorrentlistajax.php?userid=$user.id$&type=seeding",
+          "fields": {
+              "seeding": {
+                  "selector": [
+                      "b:first"
+                  ],
+                  "filters": [
+                      "query.text()"
+                  ]
+              },
+              "seedingSize": {
+                  "selector": "",
+                  "filters": [
+                      "query.text().match(/總大小：(.*?)上一頁/g)",
+                      "(query && query.length>0) ? query[0].replace('總大小：', '').replace('<< 上一頁', '').trim() : 0",
+                      "(query != 0) ? query.sizeToNumber() : 0"
+                  ]
+              }
+          }
+      }
+  },
   "collaborator": "DXV5",
   "searchEntry": [{
       "name": "全站",

--- a/resource/sites/oldtoons.world/config.json
+++ b/resource/sites/oldtoons.world/config.json
@@ -1,18 +1,21 @@
 {
-  "name": "1PTBar",
+  "name": "ihdbits",
   "schema": "NexusPHP",
-  "url": "https://1ptba.com/",
-  "description": "壹PT吧,PT下载,教育视频,课件资源,发布教育类,学习类,纪录片等资源",
-  "icon": "https://1ptba.com/kuai360/favicon.ico",
-  "tags": ["影视", "综合"],
-  "host": "1ptba.com",
+  "url": "https://oldtoons.world/",
+  "description": "",
+  "icon": "https://oldtoons.world/favicon.ico",
+  "tags": [
+    "影视"
+  ],
+  "host": "oldtoons.world",
+  "collaborator": "koal",
   "selectors": {
     "userExtendInfo": {
         "page": "/userdetails.php?id=$user.id$",
         "merge": true,
         "fields": {
           "bonus2": {
-            "selector": ["td.rowhead:contains('Seed points') + td"],
+            "selector": ["td.rowhead:contains('做种积分') + td"],
             "filters": ["query.text().replace(/,/g,'')", "parseFloat(query)"]
           }
         }

--- a/resource/sites/piggo.me/config.json
+++ b/resource/sites/piggo.me/config.json
@@ -1,0 +1,44 @@
+{
+    "name": "Pig",
+    "timezoneOffset": "+0800",
+    "description": "Pig",
+    "url": "https://piggo.me/",
+    "icon": "https://piggo.me/favicon.ico",
+    "tags": [],
+    "schema": "NexusPHP",
+    "host": "piggo.me",
+    "collaborator": "koal",
+    "selectors": {
+        "userExtendInfo": {
+            "page": "/userdetails.php?id=$user.id$",
+            "merge": true,
+            "fields": {
+              "bonus2": {
+                "selector": ["td.rowhead:contains('做种积分') + td"],
+                "filters": ["query.text().replace(/,/g,'')", "parseFloat(query)"]
+              }
+            }
+        },
+        "userSeedingTorrents": {
+            "page": "/getusertorrentlistajax.php?userid=$user.id$&type=seeding",
+            "fields": {
+                "seeding": {
+                    "selector": [
+                        "b:first"
+                    ],
+                    "filters": [
+                        "query.text()"
+                    ]
+                },
+                "seedingSize": {
+                    "selector": "",
+                    "filters": [
+                        "query.text().match(/总大小：(.*?)上一页/g)",
+                        "(query && query.length>0) ? query[0].replace('总大小：', '').replace('<< 上一页', '').trim() : 0",
+                        "(query != 0) ? query.sizeToNumber() : 0"
+                    ]
+                }
+            }
+        }
+    }
+}

--- a/resource/sites/pt.0ff.cc/config.json
+++ b/resource/sites/pt.0ff.cc/config.json
@@ -1,0 +1,44 @@
+{
+    "name": "Farm",
+    "timezoneOffset": "+0800",
+    "description": "Farm",
+    "url": "https://pt.0ff.cc/",
+    "icon": "https://pt.0ff.cc/favicon.ico",
+    "tags": [],
+    "schema": "NexusPHP",
+    "host": "pt.0ff.cc",
+    "collaborator": "koal",
+    "selectors": {
+        "userExtendInfo": {
+            "page": "/userdetails.php?id=$user.id$",
+            "merge": true,
+            "fields": {
+              "bonus2": {
+                "selector": ["td.rowhead:contains('做种积分') + td"],
+                "filters": ["query.text().replace(/,/g,'')", "parseFloat(query)"]
+              }
+            }
+        },
+        "userSeedingTorrents": {
+            "page": "/getusertorrentlistajax.php?userid=$user.id$&type=seeding",
+            "fields": {
+                "seeding": {
+                    "selector": [
+                        "b:first"
+                    ],
+                    "filters": [
+                        "query.text()"
+                    ]
+                },
+                "seedingSize": {
+                    "selector": "",
+                    "filters": [
+                        "query.text().match(/总大小：(.*?)上一页/g)",
+                        "(query && query.length>0) ? query[0].replace('总大小：', '').replace('<< 上一页', '').trim() : 0",
+                        "(query != 0) ? query.sizeToNumber() : 0"
+                    ]
+                }
+            }
+        }
+    }
+}

--- a/resource/sites/pt.btschool.club/config.json
+++ b/resource/sites/pt.btschool.club/config.json
@@ -40,6 +40,14 @@
         "seedingSize": {
           "selector": [ "td.rowhead:contains('当前做种') + td", "td.rowhead:contains('目前做種') + td", "td.rowhead:contains('Current Seeding') + td" ],
           "filters": [ "query.text().replace(/.*共计/g,'').replace(')','')", "query.sizeToNumber()" ]
+        },
+        "bonus2": {
+          "selector": ["td.rowhead:contains('传输') + td"],
+          "filters": [
+            "query.text().match(/做种积分:(.*?)注:做种积分/g)",
+            "(query && query.length>0) ? query[0].replace('做种积分:', '').replace('(注:做种积分', '').trim() : 0",
+            "(query != 0) ? parseFloat(query) : 0"
+        ]
         }
       }
     }

--- a/resource/sites/pt.newworld.plus/config.json
+++ b/resource/sites/pt.newworld.plus/config.json
@@ -1,18 +1,21 @@
 {
-  "name": "1PTBar",
+  "name": "ihdbits",
   "schema": "NexusPHP",
-  "url": "https://1ptba.com/",
-  "description": "壹PT吧,PT下载,教育视频,课件资源,发布教育类,学习类,纪录片等资源",
-  "icon": "https://1ptba.com/kuai360/favicon.ico",
-  "tags": ["影视", "综合"],
-  "host": "1ptba.com",
+  "url": "https://pt.newworld.plus/",
+  "description": "The Ultimate File Sharing Experience",
+  "icon": "https://pt.newworld.plus/favicon.ico",
+  "tags": [
+    "影视"
+  ],
+  "host": "pt.newworld.plus",
+  "collaborator": "koal",
   "selectors": {
     "userExtendInfo": {
         "page": "/userdetails.php?id=$user.id$",
         "merge": true,
         "fields": {
           "bonus2": {
-            "selector": ["td.rowhead:contains('Seed points') + td"],
+            "selector": ["td.rowhead:contains('做种积分') + td"],
             "filters": ["query.text().replace(/,/g,'')", "parseFloat(query)"]
           }
         }

--- a/resource/sites/ptchina.org/config.json
+++ b/resource/sites/ptchina.org/config.json
@@ -1,0 +1,44 @@
+{
+    "name": "PTChina",
+    "timezoneOffset": "+0800",
+    "description": "PTChina",
+    "url": "https://ptchina.org/",
+    "icon": "https://ptchina.org/favicon.ico",
+    "tags": [],
+    "schema": "NexusPHP",
+    "host": "ptchina.org",
+    "collaborator": "koal",
+    "selectors": {
+        "userExtendInfo": {
+            "page": "/userdetails.php?id=$user.id$",
+            "merge": true,
+            "fields": {
+              "bonus2": {
+                "selector": ["td.rowhead:contains('做种积分') + td"],
+                "filters": ["query.text().replace(/,/g,'')", "parseFloat(query)"]
+              }
+            }
+        },
+        "userSeedingTorrents": {
+            "page": "/getusertorrentlistajax.php?userid=$user.id$&type=seeding",
+            "fields": {
+                "seeding": {
+                    "selector": [
+                        "b:first"
+                    ],
+                    "filters": [
+                        "query.text()"
+                    ]
+                },
+                "seedingSize": {
+                    "selector": "",
+                    "filters": [
+                        "query.text().match(/总大小：(.*?)上一页/g)",
+                        "(query && query.length>0) ? query[0].replace('总大小：', '').replace('<< 上一页', '').trim() : 0",
+                        "(query != 0) ? query.sizeToNumber() : 0"
+                    ]
+                }
+            }
+        }
+    }
+}

--- a/resource/sites/pthome.net/config.json
+++ b/resource/sites/pthome.net/config.json
@@ -7,6 +7,22 @@
   "icon": "https://pthome.net/favicon.ico",
   "tags": ["综合", "影视", "游戏"],
   "host": "pthome.net",
+  "selectors": {
+      "userExtendInfo": {
+          "page": "/userdetails.php?id=$user.id$",
+          "merge": true,
+          "fields": {
+            "bonus2": {
+              "selector": ["td.rowhead:contains('做种积分') + td"],
+              "filters": [
+                "query.text().match(/(.*?)本月：/g)",
+                "(query && query.length>0) ? query[0].replace('（本月：', '').trim() : 0",
+                "(query != 0) ? parseFloat(query) : 0"
+            ]
+            }
+          }
+      }
+  },
   "searchEntryConfig": {
     "fieldSelector": {
       "progress": {

--- a/resource/sites/wintersakura.net/config.json
+++ b/resource/sites/wintersakura.net/config.json
@@ -1,0 +1,43 @@
+{
+    "name": "wintersakura",
+    "timezoneOffset": "+0800",
+    "description": "wintersakura",
+    "url": "https://wintersakura.net/",
+    "icon": "https://wintersakura.net/favicon.ico",
+    "tags": [],
+    "schema": "NexusPHP",
+    "host": "wintersakura.net",
+    "selectors": {
+        "userExtendInfo": {
+            "page": "/userdetails.php?id=$user.id$",
+            "merge": true,
+            "fields": {
+              "bonus2": {
+                "selector": ["td.rowhead:contains('做种积分') + td"],
+                "filters": ["query.text().replace(/,/g,'')", "parseFloat(query)"]
+              }
+            }
+        },
+        "userSeedingTorrents": {
+            "page": "/getusertorrentlistajax.php?userid=$user.id$&type=seeding",
+            "fields": {
+                "seeding": {
+                    "selector": [
+                        "b:first"
+                    ],
+                    "filters": [
+                        "query.text()"
+                    ]
+                },
+                "seedingSize": {
+                    "selector": "",
+                    "filters": [
+                        "query.text().match(/总大小：(.*?)上一页/g)",
+                        "(query && query.length>0) ? query[0].replace('总大小：', '').replace('<< 上一页', '').trim() : 0",
+                        "(query != 0) ? query.sizeToNumber() : 0"
+                    ]
+                }
+            }
+        }
+    }
+}

--- a/resource/sites/www.filept.com/config.json
+++ b/resource/sites/www.filept.com/config.json
@@ -1,18 +1,21 @@
 {
-  "name": "1PTBar",
+  "name": "filept",
   "schema": "NexusPHP",
-  "url": "https://1ptba.com/",
-  "description": "壹PT吧,PT下载,教育视频,课件资源,发布教育类,学习类,纪录片等资源",
-  "icon": "https://1ptba.com/kuai360/favicon.ico",
-  "tags": ["影视", "综合"],
-  "host": "1ptba.com",
+  "url": "https://www.filept.com/",
+  "description": "",
+  "icon": "https://www.filept.com/favicon.ico",
+  "tags": [
+    "影视","综合"
+  ],
+  "host": "www.filept.com",
+  "collaborator": "koal",
   "selectors": {
     "userExtendInfo": {
         "page": "/userdetails.php?id=$user.id$",
         "merge": true,
         "fields": {
           "bonus2": {
-            "selector": ["td.rowhead:contains('Seed points') + td"],
+            "selector": ["td.rowhead:contains('做种积分') + td"],
             "filters": ["query.text().replace(/,/g,'')", "parseFloat(query)"]
           }
         }

--- a/resource/sites/xinglin.one/config.json
+++ b/resource/sites/xinglin.one/config.json
@@ -1,18 +1,21 @@
 {
-  "name": "1PTBar",
+  "name": "杏林",
   "schema": "NexusPHP",
-  "url": "https://1ptba.com/",
-  "description": "壹PT吧,PT下载,教育视频,课件资源,发布教育类,学习类,纪录片等资源",
-  "icon": "https://1ptba.com/kuai360/favicon.ico",
-  "tags": ["影视", "综合"],
-  "host": "1ptba.com",
+  "url": "https://xinglin.one/",
+  "description": "杏林 - 积少成多，聚沙成塔。",
+  "icon": "https://xinglin.one/favicon.ico",
+  "tags": [
+    "医学"
+  ],
+  "host": "xinglin.one",
+  "collaborator": "koal",
   "selectors": {
     "userExtendInfo": {
         "page": "/userdetails.php?id=$user.id$",
         "merge": true,
         "fields": {
           "bonus2": {
-            "selector": ["td.rowhead:contains('Seed points') + td"],
+            "selector": ["td.rowhead:contains('做种积分') + td"],
             "filters": ["query.text().replace(/,/g,'')", "parseFloat(query)"]
           }
         }

--- a/src/options/views/Home.vue
+++ b/src/options/views/Home.vue
@@ -128,7 +128,19 @@
           <td class="number">{{ props.item.user.ratio | formatRatio }}</td>
           <td class="number">{{ props.item.user.seeding }}</td>
           <td class="number">{{ props.item.user.seedingSize | formatSize }}</td>
-          <td class="number">{{ props.item.user.bonus | formatNumber }}</td>
+          <td class="number">
+            <template v-if="props.item.schema === 'NexusPHP' && props.item.user.bonus2">                
+              <div>
+                魔力：{{ props.item.user.bonus | formatNumber }}
+              </div>
+              <div>
+                积分：{{ props.item.user.bonus2 | formatNumber }}
+              </div>
+            </template>
+            <template v-else>
+              {{ props.item.user.bonus | formatNumber }}
+            </template>
+          </td>
           <td
             class="number"
             :title="props.item.user.joinDateTime"

--- a/src/options/views/UserDataTimeline.vue
+++ b/src/options/views/UserDataTimeline.vue
@@ -152,6 +152,7 @@ import FileSaver from "file-saver";
 import domtoimage from 'dom-to-image';
 import Extension from "@/service/extension";
 import dayjs from "dayjs";
+import { PPF } from "@/service/public";
 
 const extension = new Extension();
 
@@ -253,6 +254,8 @@ export default Vue.extend({
  
         let user = site.user;
         if (user && user.name && user.joinTime) {
+          user.joinTime = PPF.transformTime(user.joinTime, site.timezoneOffset);  //add by pxwang for gpw jointime error
+          
           sites.push(site);
           if (!userNames[user.name]) {
             userNames[user.name] = 0;


### PR DESCRIPTION
1. Size转换接口问题 之前一些size的格式转换接口使用的是query.sizeToNumber()，
发现最新版本的hdfan和1pt使用了新的接口_self.getTotalSize([query]) 但是为了统一所以这两个站点的配置改回了原有接口query.sizeToNumber()，

2.站点保种体积修改
主要是由于近期很多站点升级了新版本NexusPHP导致的。
这个地方我也不知道怎么修改，是要修改NexusPHP的基础配置还是傻瓜的对使用了新版本的站点配置文件修改。这个事情的考虑已经超出我的能力范围了，所以我选择了比较基本的对新版本站点的重复性配置。

现有jquery的选择方式是基于字符串的过滤，所以现在的一些解析是以站点的默认语言版本为基础的。所以如果使用了非站点默认语言文件可能会存在问题。望知晓。

3. 保种积分 关于保种积分，是因为个人原因，有强烈的需要知道升级信息的需求，而增加保种积分信息的获取并不会额外请求数据，在个人页就可以获取到，所以增加了获取的解析以及显示。如果将来增加升级等级信息的时候是可以使用的。如果不喜可以忽略。

4.海豹的时间格式问题修改
之前修改了，提交了issue，但是因为个人不会用git，所以没有提交，只是在issue描写了修改的方法。好像看到最新版本里面没有相应修改，一并提交，如果不喜可以忽略。

koal 2022.12.4

<!-- 
感谢您提交 PR ，为了更好的进行版本迭代，请将目标分支选择为 `base:dev` ，我们会根据实际情况在后续版本中发布。

## 标题请尽量按以下格式进行描述

`<type>(<scope>): <subject>`

## type 说明

- feat: 添加新功能
- fix: 修补 bug
- docs: 文档（documentation）
- style: 格式（不影响代码运行的变动）
- refactor: 重构（即不是新增功能，也不是修改 bug 的代码变动）
- test: 增加测试
- chore: 构建过程或辅助工具的变动

## 参考文档：http://www.ruanyifeng.com/blog/2016/01/commit_message_change_log.html

## 内容说明

请尽量详细描述本次 PR 的具体作用。

本内容仅供提交前查阅，提交时请务必删除这段内容。
本内容仅供提交前查阅，提交时请务必删除这段内容。
本内容仅供提交前查阅，提交时请务必删除这段内容。
 -->