### PR TITLE
Revert "fix(jpop): 当关闭 torrent grouping 时，从搜索结果中获取种子报错 (#2001)"

### DIFF
--- a/resource/sites/jpopsuki.eu/getSearchResult.js
+++ b/resource/sites/jpopsuki.eu/getSearchResult.js
@@ -141,13 +141,6 @@ if (!"".getQueryString) {
             case row.is(".torrent_redline"):
               albumRow = row;
               albumTitle = title;
-              // 当在 Profile 里关闭 torrent grouping 时，补全单元格以让索引位置生效
-              if (cells.eq(0).text().trim() !== "") {
-                let tmpRow = row.clone().get(0);
-                tmpRow.insertCell(0);
-                cells = $(tmpRow).find(">td");
-                fieldIndex.category = 0;
-              }
               break;
 
             default:


### PR DESCRIPTION
今天搜索jpop的种子，才发现之前的PR只修了搜索报错的问题，搜索结果有几个字段串列了没处理。
新项目ptd也能用了，所以还是个人资料里改回默认设置凑合用吧，这个不管了。